### PR TITLE
Fix prefixes of "They" being mistaken for "The"

### DIFF
--- a/Sources/Music/Artist.swift
+++ b/Sources/Music/Artist.swift
@@ -34,6 +34,9 @@ extension Artist: Comparable {
           "A"
           "An"
         }
+        OneOrMore {
+          .whitespace
+        }
       }
       ZeroOrMore {
         ChoiceOf {


### PR DESCRIPTION
- Ensure there is whitespace after the prefix of "The", "A", "An"