### PR TITLE
Add ability to sort albums better

### DIFF
--- a/Sources/Site/Music/Album.swift
+++ b/Sources/Site/Music/Album.swift
@@ -27,23 +27,3 @@ public struct Album: Codable, Equatable {
     self.compilation = compilation
   }
 }
-
-extension Album: Comparable {
-  internal var isUnknownRelease: Bool {
-    return release == nil
-  }
-
-  public static func < (lhs: Album, rhs: Album) -> Bool {
-    if lhs.isUnknownRelease, rhs.isUnknownRelease {
-      return false
-    }
-
-    if let lhRelease = lhs.release {
-      if let rhRelease = rhs.release {
-        return lhRelease < rhRelease
-      }
-      return true
-    }
-    return false
-  }
-}

--- a/Sources/Site/Music/Music+Comparator.swift
+++ b/Sources/Site/Music/Music+Comparator.swift
@@ -1,0 +1,41 @@
+//
+//  Music+Comparator.swift
+//
+//
+//  Created by Greg Bolsinga on 2/24/23.
+//
+
+import Foundation
+
+extension Music {
+  public func albumCompare(lhs: Album, rhs: Album) -> Bool {
+    if let lhRelease = lhs.release, let rhRelease = rhs.release {
+      if lhRelease == rhRelease {
+        let lhArtist = self.artistForAlbum(lhs)
+        let rhArtist = self.artistForAlbum(rhs)
+
+        if let lhArtist, let rhArtist {
+          if lhArtist == rhArtist {
+            return libraryCompare(lhs: lhs.title, rhs: rhs.title)
+          }
+          return libraryCompare(lhs: lhArtist, rhs: rhArtist)
+        }
+
+        if lhArtist == nil {
+          return true
+        }
+
+        assert(rhArtist == nil)
+        return false
+      }
+      return lhRelease < rhRelease
+    }
+
+    if lhs.release == nil {
+      return true
+    }
+
+    assert(rhs.release == nil)
+    return false
+  }
+}

--- a/Sources/Site/Utility/LibraryComparator.swift
+++ b/Sources/Site/Utility/LibraryComparator.swift
@@ -14,8 +14,15 @@ public protocol LibraryComparable {
 }
 
 public func libraryCompare(lhs: any LibraryComparable, rhs: any LibraryComparable) -> Bool {
-  var lhSort = lhs.sortname ?? lhs.name
-  var rhSort = rhs.sortname ?? rhs.name
+  let lhSort = lhs.sortname ?? lhs.name
+  let rhSort = rhs.sortname ?? rhs.name
+
+  return libraryCompare(lhs: lhSort, rhs: rhSort)
+}
+
+public func libraryCompare(lhs: String, rhs: String) -> Bool {
+  var lhSort = lhs
+  var rhSort = rhs
 
   let regex = Regex {
     ZeroOrMore {

--- a/Sources/site_tool/Program.swift
+++ b/Sources/site_tool/Program.swift
@@ -64,7 +64,7 @@ struct Program: AsyncParsableCommand {
         print(music.description(for: show))
       }
 
-      for album in music.albums.sorted(by: <).reversed() {
+      for album in music.albums.sorted(by: music.albumCompare(lhs:rhs:)) {
         print(music.description(for: album))
       }
 


### PR DESCRIPTION
- LibraryComparator now also has a variant that just takes strings
- album comparison first sorts by date, then artist, then album title.