### PR TITLE
Fix album comparator tests

### DIFF
--- a/Tests/SiteTests/AlbumComparatorTests.swift
+++ b/Tests/SiteTests/AlbumComparatorTests.swift
@@ -10,6 +10,9 @@ import XCTest
 @testable import Site
 
 final class AlbumComparatorTests: XCTestCase {
+  let aTitle = "Atlas"
+  let bTitle = "Banana"
+
   let unknownDate = PartialDate()
   let date = PartialDate(year: 1996)
 
@@ -23,8 +26,8 @@ final class AlbumComparatorTests: XCTestCase {
   }
 
   func testUnknownRelease_UnknownRelease() throws {
-    let album1 = Album(id: "a0", performer: artist1.id, songs: [], title: "A Title")
-    let album2 = Album(id: "a1", performer: artist2.id, songs: [], title: "B Title")
+    let album1 = Album(id: "a0", performer: artist1.id, songs: [], title: aTitle)
+    let album2 = Album(id: "a1", performer: artist2.id, songs: [], title: bTitle)
 
     let music = createMusic(albums: [album1, album2], artists: [artist1, artist2])
 
@@ -36,8 +39,8 @@ final class AlbumComparatorTests: XCTestCase {
   }
 
   func testUnknownRelease_fullDate() throws {
-    let album1 = Album(id: "a0", performer: artist1.id, songs: [], title: "A Title")
-    let album2 = Album(id: "a1", performer: artist2.id, release: date, songs: [], title: "B Title")
+    let album1 = Album(id: "a0", performer: artist1.id, songs: [], title: aTitle)
+    let album2 = Album(id: "a1", performer: artist2.id, release: date, songs: [], title: bTitle)
 
     let music = createMusic(albums: [album1, album2], artists: [artist1, artist2])
 
@@ -49,8 +52,8 @@ final class AlbumComparatorTests: XCTestCase {
   func testFullDate_fullDate() throws {
     let album1 = Album(
       id: "a0", performer: artist1.id, release: PartialDate(year: date.year! - 1), songs: [],
-      title: "A Title")
-    let album2 = Album(id: "a1", performer: artist2.id, release: date, songs: [], title: "B Title")
+      title: aTitle)
+    let album2 = Album(id: "a1", performer: artist2.id, release: date, songs: [], title: bTitle)
 
     let music = createMusic(albums: [album1, album2], artists: [artist1, artist2])
 
@@ -60,8 +63,8 @@ final class AlbumComparatorTests: XCTestCase {
   }
 
   func testSameDates_knownArtists() throws {
-    let album1 = Album(id: "a0", performer: artist1.id, release: date, songs: [], title: "A Title")
-    let album2 = Album(id: "a1", performer: artist2.id, release: date, songs: [], title: "B Title")
+    let album1 = Album(id: "a0", performer: artist1.id, release: date, songs: [], title: aTitle)
+    let album2 = Album(id: "a1", performer: artist2.id, release: date, songs: [], title: bTitle)
 
     let music = createMusic(albums: [album1, album2], artists: [artist1, artist2])
 
@@ -71,8 +74,8 @@ final class AlbumComparatorTests: XCTestCase {
   }
 
   func testSameDates_oneUnknownArtists() throws {
-    let album1 = Album(id: "a0", performer: artist1.id, release: date, songs: [], title: "A Title")
-    let album2 = Album(id: "a1", release: date, songs: [], title: "B Title")
+    let album1 = Album(id: "a0", performer: artist1.id, release: date, songs: [], title: aTitle)
+    let album2 = Album(id: "a1", release: date, songs: [], title: bTitle)
 
     let music = createMusic(albums: [album1, album2], artists: [artist1])
 
@@ -86,8 +89,8 @@ final class AlbumComparatorTests: XCTestCase {
   }
 
   func testSameDates_twoUnknownArtists() throws {
-    let album1 = Album(id: "a0", release: date, songs: [], title: "A Title")
-    let album2 = Album(id: "a1", release: date, songs: [], title: "B Title")
+    let album1 = Album(id: "a0", release: date, songs: [], title: aTitle)
+    let album2 = Album(id: "a1", release: date, songs: [], title: bTitle)
 
     let music = createMusic(albums: [album1, album2], artists: [])
 
@@ -99,25 +102,21 @@ final class AlbumComparatorTests: XCTestCase {
   }
 
   func testSameDates_sameArtists() throws {
-    let album1 = Album(id: "a0", performer: artist1.id, release: date, songs: [], title: "A Title")
-    let album2 = Album(id: "a1", performer: artist1.id, release: date, songs: [], title: "B Title")
+    let album1 = Album(id: "a0", performer: artist1.id, release: date, songs: [], title: aTitle)
+    let album2 = Album(id: "a1", performer: artist1.id, release: date, songs: [], title: bTitle)
 
-    let music = createMusic(albums: [album1, album2], artists: [artist1, artist2])
+    let music = createMusic(albums: [album1, album2], artists: [artist1])
 
     XCTAssertNotEqual(album1, album2)
-    XCTExpectFailure("albums with identical performers and dates should sort by album title") {
-      XCTAssertTrue(music.albumCompare(lhs: album1, rhs: album2))
-    }
-    XCTExpectFailure("albums with identical performers and dates should sort by album title") {
-      XCTAssertFalse(music.albumCompare(lhs: album2, rhs: album1))
-    }
+    XCTAssertTrue(music.albumCompare(lhs: album1, rhs: album2))
+    XCTAssertFalse(music.albumCompare(lhs: album2, rhs: album1))
   }
 
   func testSameDates_sameArtists_sameTitle() throws {
-    let album1 = Album(id: "a0", performer: artist1.id, release: date, songs: [], title: "A Title")
-    let album2 = Album(id: "a1", performer: artist1.id, release: date, songs: [], title: "A Title")
+    let album1 = Album(id: "a0", performer: artist1.id, release: date, songs: [], title: aTitle)
+    let album2 = Album(id: "a1", performer: artist1.id, release: date, songs: [], title: aTitle)
 
-    let music = createMusic(albums: [album1, album2], artists: [artist1, artist2])
+    let music = createMusic(albums: [album1, album2], artists: [artist1])
 
     XCTAssertNotEqual(album1, album2)
     XCTExpectFailure(
@@ -129,10 +128,10 @@ final class AlbumComparatorTests: XCTestCase {
   }
 
   func testEquality() throws {
-    let album1 = Album(id: "a0", performer: artist1.id, release: date, songs: [], title: "A Title")
+    let album1 = Album(id: "a0", performer: artist1.id, release: date, songs: [], title: aTitle)
     let album2 = album1
 
-    let music = createMusic(albums: [album1, album2], artists: [artist1, artist2])
+    let music = createMusic(albums: [album1, album2], artists: [artist1])
 
     XCTAssertEqual(album1, album2)
     XCTAssertFalse(music.albumCompare(lhs: album1, rhs: album2))


### PR DESCRIPTION
- Use test album titles that will sort properly. 
- -- "A Title" became "Title" which sorted after "B Title". :)