### PR TITLE
Parallel sort tokens

### DIFF
--- a/Sources/Site/Music/LibraryComparator+Music.swift
+++ b/Sources/Site/Music/LibraryComparator+Music.swift
@@ -1,0 +1,21 @@
+//
+//  LibraryComparator+Music.swift
+//
+//
+//  Created by Greg Bolsinga on 4/23/23.
+//
+
+import Foundation
+
+extension LibraryComparator {
+  public static func create(music: Music) async -> LibraryComparator {
+    let tokenMap = music.artists.reduce(
+      into: music.venues.reduce(into: [:]) {
+        $0[$1.id] = $1.librarySortToken
+      }
+    ) {
+      $0[$1.id] = $1.librarySortToken
+    }
+    return LibraryComparator(tokenMap: tokenMap)
+  }
+}

--- a/Sources/Site/Music/Vault.swift
+++ b/Sources/Site/Music/Vault.swift
@@ -10,21 +10,23 @@ import Foundation
 public struct Vault {
   public let music: Music
   public let lookup: Lookup
-  public let comparator = LibraryComparator()
+  public let comparator: LibraryComparator
 
   public init(music: Music) {
     // non-parallel, used for previews, tests
-    self.init(music: music, lookup: Lookup(music: music))
+    self.init(music: music, lookup: Lookup(music: music), comparator: LibraryComparator())
   }
 
-  internal init(music: Music, lookup: Lookup) {
+  internal init(music: Music, lookup: Lookup, comparator: LibraryComparator) {
     self.music = music
     self.lookup = lookup
+    self.comparator = comparator
   }
 
   public static func create(music: Music) async -> Vault {
     // parallel
     let lookup = await Lookup.create(music: music)
-    return Vault(music: music, lookup: lookup)
+    let comparator = await LibraryComparator.create(music: music)
+    return Vault(music: music, lookup: lookup, comparator: comparator)
   }
 }

--- a/Sources/Site/Utility/LibraryComparable.swift
+++ b/Sources/Site/Utility/LibraryComparable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol LibraryComparable {
+public protocol LibraryComparable: Identifiable {
   var sortname: String? { get }
   var name: String { get }
 }

--- a/Sources/Site/Utility/LibraryComparator.swift
+++ b/Sources/Site/Utility/LibraryComparator.swift
@@ -8,8 +8,17 @@
 import Foundation
 
 public struct LibraryComparator {
-  public func libraryCompare(lhs: any LibraryComparable, rhs: any LibraryComparable) -> Bool {
-    return libraryCompareTokens(lhs: lhs.librarySortToken, rhs: rhs.librarySortToken)
+
+  let tokenMap: [String: String]
+
+  public init(tokenMap: [String: String] = [:]) {
+    self.tokenMap = tokenMap
+  }
+
+  public func libraryCompare<T>(lhs: T, rhs: T) -> Bool where T: LibraryComparable, T.ID == String {
+    let lhToken = tokenMap[lhs.id] ?? lhs.librarySortToken
+    let rhToken = tokenMap[rhs.id] ?? rhs.librarySortToken
+    return libraryCompareTokens(lhs: lhToken, rhs: rhToken)
   }
 
   public func libraryCompare(lhs: String, rhs: String) -> Bool {


### PR DESCRIPTION
- Generate all the sort tokens for LibraryComparables at start time in parallel with other caching
- Speeds up some sorting when showing the UI