### PR TITLE
Add Vault.LibrarySectioner

### DIFF
--- a/Sources/Site/Music/UI/ArtistList.swift
+++ b/Sources/Site/Music/UI/ArtistList.swift
@@ -16,7 +16,7 @@ struct ArtistList: View {
   }
 
   var body: some View {
-    LibraryComparableList(items: artists) {
+    LibraryComparableList(items: artists, sectioner: vault.sectioner) {
       String(
         localized: "\(vault.lookup.showsForArtist($0).count) Show(s)", bundle: .module,
         comment: "Value for the Artist # of Shows.")

--- a/Sources/Site/Music/UI/LibraryComparableList.swift
+++ b/Sources/Site/Music/UI/LibraryComparableList.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct LibraryComparableList<T>: View where T: LibraryComparable, T: Identifiable, T: Hashable {
   let items: [T]
+  let sectioner: LibrarySectioner
   let contentValue: (T) -> String
-  let sectioner = LibrarySectioner()
 
   @State private var searchString: String = ""
 
@@ -85,7 +85,7 @@ struct LibraryComparableList_Previews: PreviewProvider {
     let vault = Vault(music: music)
 
     NavigationStack {
-      LibraryComparableList(items: music.artists) {
+      LibraryComparableList(items: music.artists, sectioner: vault.sectioner) {
         "\(vault.lookup.showsForArtist($0).count) Shows"
       }
       .navigationTitle("Artists")
@@ -94,10 +94,12 @@ struct LibraryComparableList_Previews: PreviewProvider {
     }
 
     NavigationStack {
-      LibraryComparableList(items: music.venues) { "\(vault.lookup.showsForVenue($0).count) Shows" }
-        .navigationTitle("Venues")
-        .environment(\.vault, vault)
-        .musicDestinations()
+      LibraryComparableList(items: music.venues, sectioner: vault.sectioner) {
+        "\(vault.lookup.showsForVenue($0).count) Shows"
+      }
+      .navigationTitle("Venues")
+      .environment(\.vault, vault)
+      .musicDestinations()
     }
   }
 }

--- a/Sources/Site/Music/UI/VenueList.swift
+++ b/Sources/Site/Music/UI/VenueList.swift
@@ -16,7 +16,7 @@ struct VenueList: View {
   }
 
   var body: some View {
-    LibraryComparableList(items: venues) {
+    LibraryComparableList(items: venues, sectioner: vault.sectioner) {
       String(
         localized: "\(vault.lookup.showsForVenue($0).count) Show(s)", bundle: .module,
         comment: "Value for the Venue # of Shows.")

--- a/Sources/Site/Music/Vault.swift
+++ b/Sources/Site/Music/Vault.swift
@@ -11,6 +11,7 @@ public struct Vault {
   public let music: Music
   public let lookup: Lookup
   public let comparator: LibraryComparator
+  internal let sectioner = LibrarySectioner()
 
   public init(music: Music) {
     // non-parallel, used for previews, tests


### PR DESCRIPTION
- This way a pre-populated LibrarySectioner with a cache will be passed to every LibraryComparableList.