### PR TITLE
Add batch geocoding

### DIFF
--- a/Sources/Site/Music/Atlas+BatchGeocoding.swift
+++ b/Sources/Site/Music/Atlas+BatchGeocoding.swift
@@ -1,0 +1,75 @@
+//
+//  Atlas+BatchGeocoding.swift
+//
+//
+//  Created by Greg Bolsinga on 5/3/23.
+//
+
+import CoreLocation
+import Foundation
+
+extension Array {
+  fileprivate func batched(into size: Int) -> [[Element]] {
+    return stride(from: 0, to: count, by: size).map {
+      Array(self[$0..<Swift.min($0 + size, count)])
+    }
+  }
+}
+
+private enum Constants {
+  static let maxRequests = 50
+  static let timeUntilReset = 60
+}
+
+private enum ThrottleError: Error {
+  case throttled
+}
+
+extension NSError {
+  fileprivate func throwIfThrottled() throws {
+    guard self.code == CLError.network.rawValue, self.domain == kCLErrorDomain else { return }
+    throw ThrottleError.throttled
+  }
+}
+
+extension Atlas {
+  public func geocode(batch locations: [Location]) async {
+    let uncachedLocations = locations.filter { cache[$0] == nil }
+
+    do {
+      let batchesOfLocations = uncachedLocations.batched(into: Constants.maxRequests)
+      let lastBatchOfLocations = batchesOfLocations.last
+
+      for batchedLocations in batchesOfLocations {
+        let clock = ContinuousClock()
+        let until = clock.now + .seconds(Constants.timeUntilReset)
+
+        for location in batchedLocations {
+          do {
+            let _ = try await geocode(location)
+          } catch let error as NSError {
+            try error.throwIfThrottled()
+          }
+        }
+
+        if batchedLocations != lastBatchOfLocations {
+          // end of batch, wait for throttle
+          do {
+            try await Task.sleep(until: until, clock: clock)
+          } catch {}
+        }
+      }
+    } catch ThrottleError.throttled {
+      // wait for throttle
+      do {
+        try await Task.sleep(until: .now + .seconds(Constants.timeUntilReset), clock: .continuous)
+      } catch {}
+
+      // start over
+      await geocode(batch: uncachedLocations)
+    } catch {
+      print("Unknown Batch Geocoding Error: \(error)")
+    }
+    print("Batch Geocoding Completed.")
+  }
+}

--- a/Sources/Site/Music/Atlas.swift
+++ b/Sources/Site/Music/Atlas.swift
@@ -10,7 +10,7 @@ import Foundation
 import MapKit
 
 actor Atlas {
-  var cache: [Location: CLPlacemark] = [:]
+  internal var cache: [Location: CLPlacemark] = [:]
 
   public func geocode(_ location: Location) async throws -> CLPlacemark {
     if let result = cache[location] {

--- a/Sources/Site/Music/Vault.swift
+++ b/Sources/Site/Music/Vault.swift
@@ -50,7 +50,13 @@ public struct Vault {
       timestamp: music.timestamp,
       venues: sortedVenues)
 
-    return Vault(
+    let v = Vault(
       music: sortedMusic, lookup: lookup, comparator: comparator, sectioner: await sectioner)
+
+//    Task {
+//      await v.atlas.geocode(batch: v.music.venues.map { $0.location })
+//    }
+
+    return v
   }
 }


### PR DESCRIPTION
- Implementation is tested and ready. It is not called at this time, since there is not yet a client.
- Handles ignoring most errors, except for when it has been throttled. If throttled, it will wait 60 seconds to try the next batch.
- The constants for the batch size and timeout were learned from the console log. Unfortunately the CLError does not have the underlying GEOError to dynamically learn the maxRequests and timeUntilReset values.
- Fixes #239