### PR TITLE
Do not repeat in determinateTimer if there is an error

### DIFF
--- a/Sources/Site/Music/UI/DeterminateTimerModifier.swift
+++ b/Sources/Site/Music/UI/DeterminateTimerModifier.swift
@@ -40,13 +40,13 @@ struct DeterminateTimerModifier: ViewModifier {
       .onAppear {
         mainDeferredAction()
       }.task {
-        repeat {
-          do {
+        do {
+          repeat {
             try await Task.sleep(
               until: .now + .seconds(Date.now.timeInterval(until: trigger)), clock: .continuous)
             mainDeferredAction()
-          } catch {}
-        } while true
+          } while true
+        } catch {}
       }
   }
 }


### PR DESCRIPTION
- When the View this ViewModifier is attached to is gone the .task gets canceled, which throws.
- No longer getting a warm device. :)