### PR TITLE
ViewBuilder LibraryComparable item content Views

### DIFF
--- a/Sources/Site/Music/UI/ArtistList.swift
+++ b/Sources/Site/Music/UI/ArtistList.swift
@@ -17,8 +17,8 @@ struct ArtistList: View {
       searchPrompt: String(
         localized: "Artist Names", bundle: .module, comment: "ArtistList searchPrompt")
     ) {
-      String(
-        localized: "\(vault.music.showsForArtist($0).count) Show(s)", bundle: .module,
+      Text(
+        "\(vault.music.showsForArtist($0).count) Show(s)", bundle: .module,
         comment: "Value for the Artist # of Shows.")
     }
     .navigationTitle(Text("Artists", bundle: .module, comment: "Title for the Artist Detail"))

--- a/Sources/Site/Music/UI/LibraryComparableList.swift
+++ b/Sources/Site/Music/UI/LibraryComparableList.swift
@@ -7,12 +7,12 @@
 
 import SwiftUI
 
-struct LibraryComparableList<T>: View
+struct LibraryComparableList<T, Content: View>: View
 where T: LibraryComparable, T: Identifiable, T: Hashable, T.ID == String {
   let items: [T]
   let sectioner: LibrarySectioner
   let searchPrompt: String
-  let contentValue: (T) -> String
+  @ViewBuilder let contentView: (T) -> Content
 
   @State private var searchString: String = ""
 
@@ -37,7 +37,11 @@ where T: LibraryComparable, T: Identifiable, T: Hashable, T.ID == String {
         Section {
           ForEach(sectionMap[section] ?? []) { item in
             NavigationLink(value: item) {
-              LabeledContent(item.name, value: contentValue(item))
+              LabeledContent {
+                contentView(item)
+              } label: {
+                Text(item.name)
+              }
             }
           }
         } header: {
@@ -89,7 +93,7 @@ struct LibraryComparableList_Previews: PreviewProvider {
       LibraryComparableList(
         items: music.artists, sectioner: vault.sectioner, searchPrompt: "Artist Names"
       ) {
-        "\(vault.music.showsForArtist($0).count) Shows"
+        Text(vault.music.showsForArtist($0).count.formatted(.number))
       }
       .navigationTitle("Artists")
       .environment(\.vault, vault)
@@ -99,9 +103,7 @@ struct LibraryComparableList_Previews: PreviewProvider {
     NavigationStack {
       LibraryComparableList(
         items: music.venues, sectioner: vault.sectioner, searchPrompt: "Venue Names"
-      ) {
-        "\(vault.music.showsForVenue($0).count) Shows"
-      }
+      ) { _ in }
       .navigationTitle("Venues")
       .environment(\.vault, vault)
       .musicDestinations()

--- a/Sources/Site/Music/UI/VenueList.swift
+++ b/Sources/Site/Music/UI/VenueList.swift
@@ -17,8 +17,8 @@ struct VenueList: View {
       searchPrompt: String(
         localized: "Venue Names", bundle: .module, comment: "VenueList searchPrompt")
     ) {
-      String(
-        localized: "\(vault.music.showsForVenue($0).count) Show(s)", bundle: .module,
+      Text(
+        "\(vault.music.showsForVenue($0).count) Show(s)", bundle: .module,
         comment: "Value for the Venue # of Shows.")
     }
     .navigationTitle(Text("Venues", bundle: .module, comment: "Title for the Venue Detail"))


### PR DESCRIPTION
- This will allow it to be "empty" for certain UI situations (such as when the Section.header contains the information).