### PR TITLE
LibraryComparableList now has a switchable LibrarySectionAlgorithm

### DIFF
--- a/Sources/Site/Music/UI/ArchiveCategoryList.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryList.swift
@@ -12,6 +12,8 @@ public struct ArchiveCategoryList: View {
   @Environment(\.vault) private var vault: Vault
 
   @State private var todayShows: [Show] = []
+  @State private var venueListAlgorithm: LibrarySectionAlgorithm = .alphabetical
+  @State private var artistListAlgorithm: LibrarySectionAlgorithm = .alphabetical
 
   private var music: Music {
     vault.music
@@ -49,9 +51,9 @@ public struct ArchiveCategoryList: View {
       case .shows:
         ShowYearList(shows: music.shows)
       case .venues:
-        VenueList(venues: music.venues)
+        VenueList(venues: music.venues, algorithm: $venueListAlgorithm)
       case .artists:
-        ArtistList(artists: music.artists)
+        ArtistList(artists: music.artists, algorithm: $artistListAlgorithm)
       }
     }
     .musicDestinations()

--- a/Sources/Site/Music/UI/ArtistList.swift
+++ b/Sources/Site/Music/UI/ArtistList.swift
@@ -11,6 +11,8 @@ struct ArtistList: View {
   @Environment(\.vault) private var vault: Vault
   let artists: [Artist]
 
+  @Binding var algorithm: LibrarySectionAlgorithm
+
   var body: some View {
     LibraryComparableList(
       items: artists,
@@ -18,7 +20,7 @@ struct ArtistList: View {
         localized: "Artist Names", bundle: .module, comment: "ArtistList searchPrompt"),
       itemContentValue: {
         vault.lookup.showRank(artist: $0).count
-      }
+      }, algorithm: $algorithm
     )
     .navigationTitle(Text("Artists", bundle: .module, comment: "Title for the Artist Detail"))
   }
@@ -60,7 +62,7 @@ struct ArtistList_Previews: PreviewProvider {
     let vault = Vault(music: music)
 
     NavigationStack {
-      ArtistList(artists: music.artists)
+      ArtistList(artists: music.artists, algorithm: .constant(.alphabetical))
         .environment(\.vault, vault)
         .musicDestinations()
     }

--- a/Sources/Site/Music/UI/LibraryComparableList.swift
+++ b/Sources/Site/Music/UI/LibraryComparableList.swift
@@ -16,7 +16,7 @@ where T: LibraryComparable, T: Identifiable, T: Hashable, T.ID == String {
   let itemContentValue: (T) -> Int
 
   @State private var searchString: String = ""
-  let algorithm = LibrarySectionAlgorithm.alphabetical
+  @Binding var algorithm: LibrarySectionAlgorithm
 
   private var filteredItems: [T] {
     guard !searchString.isEmpty else { return items }
@@ -53,6 +53,19 @@ where T: LibraryComparable, T: Identifiable, T: Hashable, T.ID == String {
     }
     .listStyle(.plain)
     .searchable(text: $searchString, prompt: searchPrompt)
+    .toolbar {
+      ToolbarItem(placement: .primaryAction) {
+        Picker(selection: $algorithm) {
+          ForEach(LibrarySectionAlgorithm.allCases, id: \.self) { category in
+            Text(category.localizedString).tag(category)
+          }
+        } label: {
+          Text(
+            "Sort Order", bundle: .module,
+            comment: "Shown to change the sort order of the LibraryComparableList.")
+        }
+      }
+    }
   }
 }
 
@@ -97,7 +110,7 @@ struct LibraryComparableList_Previews: PreviewProvider {
         searchPrompt: "Artist Names",
         itemContentValue: {
           vault.music.showsForArtist($0).count
-        }
+        }, algorithm: .constant(.alphabetical)
       )
       .navigationTitle("Artists")
       .environment(\.vault, vault)
@@ -110,7 +123,7 @@ struct LibraryComparableList_Previews: PreviewProvider {
         searchPrompt: "Venue Names",
         itemContentValue: { _ in
           0
-        }
+        }, algorithm: .constant(.alphabetical)
       )
       .navigationTitle("Venues")
       .environment(\.vault, vault)

--- a/Sources/Site/Music/UI/VenueList.swift
+++ b/Sources/Site/Music/UI/VenueList.swift
@@ -11,6 +11,8 @@ struct VenueList: View {
   @Environment(\.vault) private var vault: Vault
   let venues: [Venue]
 
+  @Binding var algorithm: LibrarySectionAlgorithm
+
   var body: some View {
     LibraryComparableList(
       items: venues,
@@ -18,7 +20,7 @@ struct VenueList: View {
         localized: "Venue Names", bundle: .module, comment: "VenueList searchPrompt"),
       itemContentValue: {
         vault.lookup.venueRank(venue: $0).count
-      }
+      }, algorithm: $algorithm
     )
     .navigationTitle(Text("Venues", bundle: .module, comment: "Title for the Venue Detail"))
   }
@@ -60,7 +62,7 @@ struct VenueList_Previews: PreviewProvider {
     let vault = Vault(music: music)
 
     NavigationStack {
-      VenueList(venues: music.venues)
+      VenueList(venues: music.venues, algorithm: .constant(.alphabetical))
         .environment(\.vault, vault)
         .musicDestinations()
     }

--- a/Sources/Site/Resources/en.lproj/Localizable.strings
+++ b/Sources/Site/Resources/en.lproj/Localizable.strings
@@ -76,6 +76,9 @@ Title of the Shows section of VenueDetail
 ArchiveCategory Shows */
 "Shows" = "Shows";
 
+/* Shown to change the sort order of the LibraryComparableList. */
+"Sort Order" = "Sort Order";
+
 /* Label in the chart for the State in StateChart. */
 "State" = "State";
 


### PR DESCRIPTION
It's @Binding, and the @State is held in the parent of ArtistList and VenueList so they persist.

Fixes #242 Fixes #243 Fixes #244 Fixes #245 