### PR TITLE
Fix Year Span to match OS .relative formatting calculation

### DIFF
--- a/Sources/Site/Music/Music+Ranking.swift
+++ b/Sources/Site/Music/Music+Ranking.swift
@@ -28,15 +28,9 @@ extension Music {
     return computeRankings(items: venuesShowCount)
   }
 
-  private func computedYears(shows: [Show]) -> [PartialDate] {
-    return Array(
-      Set(shows.map { $0.date.year != nil ? PartialDate(year: $0.date.year!) : PartialDate() })
-    ).sorted(by: <)
-  }
-
   var artistSpanRankings: (ItemRankings, ItemRankingMap) {
     let artistShowSpans: [(Artist.ID, Int)] = self.artists.reduce(into: [:]) {
-      $0[$1.id] = computedYears(shows: self.showsForArtist($1)).yearSpan
+      $0[$1.id] = self.showsForArtist($1).map { $0.date }.yearSpan
     }.map { $0 }
 
     return computeRankings(items: artistShowSpans)
@@ -44,7 +38,7 @@ extension Music {
 
   var venueSpanRankings: (ItemRankings, ItemRankingMap) {
     let venueShowSpans: [(Venue.ID, Int)] = self.venues.reduce(into: [:]) {
-      $0[$1.id] = computedYears(shows: self.showsForVenue($1)).yearSpan
+      $0[$1.id] = self.showsForVenue($1).map { $0.date }.yearSpan
     }.map { $0 }
 
     return computeRankings(items: venueShowSpans)

--- a/Sources/Site/Music/Music+Ranking.swift
+++ b/Sources/Site/Music/Music+Ranking.swift
@@ -36,7 +36,7 @@ extension Music {
 
   var artistSpanRankings: (ItemRankings, ItemRankingMap) {
     let artistShowSpans: [(Artist.ID, Int)] = self.artists.reduce(into: [:]) {
-      $0[$1.id] = computedYears(shows: self.showsForArtist($1)).yearSpan()
+      $0[$1.id] = computedYears(shows: self.showsForArtist($1)).yearSpan
     }.map { $0 }
 
     return computeRankings(items: artistShowSpans)
@@ -44,7 +44,7 @@ extension Music {
 
   var venueSpanRankings: (ItemRankings, ItemRankingMap) {
     let venueShowSpans: [(Venue.ID, Int)] = self.venues.reduce(into: [:]) {
-      $0[$1.id] = computedYears(shows: self.showsForVenue($1)).yearSpan()
+      $0[$1.id] = computedYears(shows: self.showsForVenue($1)).yearSpan
     }.map { $0 }
 
     return computeRankings(items: venueShowSpans)

--- a/Sources/Site/Music/PartialDate+Span.swift
+++ b/Sources/Site/Music/PartialDate+Span.swift
@@ -17,9 +17,12 @@ extension Sequence<PartialDate> {
     guard knownDates.count > 1 else { return 1 }
 
     if let max = knownDates.max(), let min = knownDates.min() {
-      let comps = Calendar.autoupdatingCurrent.dateComponents([.year], from: min, to: max)
-      if let year = comps.year {
-        return year
+      let comps = Calendar.autoupdatingCurrent.dateComponents(
+        [.year, .month, .day], from: min, to: max)
+      if let year = comps.year, let month = comps.month, let day = comps.day {
+        guard year > 0 else { return 1 } // It's less than a year difference, so the sequence spans 1 year.
+        guard year == 1 else { return year } // It's more than 1 year, so just count the years, no rounding. Matches RelativeDateTimeFormatter() output.
+        return year + (month > 0 ? 1 : (day > 0 ? 1 : 0)) // It's 1 year and some time.
       }
     }
 

--- a/Sources/Site/Music/PartialDate+Span.swift
+++ b/Sources/Site/Music/PartialDate+Span.swift
@@ -8,11 +8,21 @@
 import Foundation
 
 extension Sequence<PartialDate> {
-  func yearSpan() -> Int {
-    let knownYears = self.filter { $0.year != nil }.sorted(by: <)
-    if let first = knownYears.first?.year, let last = knownYears.last?.year {
-      return abs(last - first) + 1
+  var yearSpan: Int {
+    let uniqueDates = Set(self)
+    guard !uniqueDates.isEmpty else { return 0 }
+    guard uniqueDates.count > 1 else { return 1 }
+
+    let knownDates = uniqueDates.filter { $0.year != nil }.compactMap { $0.date }.sorted()
+    guard knownDates.count > 1 else { return 1 }
+
+    if let max = knownDates.max(), let min = knownDates.min() {
+      let comps = Calendar.autoupdatingCurrent.dateComponents([.year], from: min, to: max)
+      if let year = comps.year {
+        return year
+      }
     }
-    return knownYears.count != 0 ? knownYears.count : Set(self.filter { $0.year == nil }).count
+
+    return knownDates.count
   }
 }

--- a/Tests/SiteTests/PartialDateTests.swift
+++ b/Tests/SiteTests/PartialDateTests.swift
@@ -126,19 +126,23 @@ final class PartialDateTests: XCTestCase {
     let date1 = PartialDate(year: 1995, month: 12, day: 31)
     let date2 = PartialDate(year: 1997)
     let unknownDate = PartialDate()
+    let unwoundDate = PartialDate(year: 1995, month: 4, day: 1)
+    let unwoundDate28YearsAgo = PartialDate(year: 2023, month: 5, day: 26)
 
-    XCTAssertEqual([date1].yearSpan(), 1)
-    XCTAssertEqual([date2].yearSpan(), 1)
-    XCTAssertEqual([unknownDate].yearSpan(), 1)
+    XCTAssertEqual([date1].yearSpan, 1)
+    XCTAssertEqual([date2].yearSpan, 1)
+    XCTAssertEqual([unknownDate].yearSpan, 1)
 
-    XCTAssertEqual([date1, date2].yearSpan(), 3)
-    XCTAssertEqual([date1, date1].yearSpan(), 1)
-    XCTAssertEqual([date2, date2].yearSpan(), 1)
+    XCTAssertEqual([date1, date2].yearSpan, 1)
+    XCTAssertEqual([date1, date1].yearSpan, 1)
+    XCTAssertEqual([date2, date2].yearSpan, 1)
 
-    XCTAssertEqual([unknownDate, unknownDate].yearSpan(), 1)
-    XCTAssertEqual([unknownDate, date1].yearSpan(), 1)
-    XCTAssertEqual([unknownDate, date1, date2].yearSpan(), 3)
+    XCTAssertEqual([unknownDate, unknownDate].yearSpan, 1)
+    XCTAssertEqual([unknownDate, date1].yearSpan, 1)
+    XCTAssertEqual([unknownDate, date1, date2].yearSpan, 1)
 
-    XCTAssertEqual([PartialDate]().yearSpan(), 0)
+    XCTAssertEqual([PartialDate]().yearSpan, 0)
+
+    XCTAssertEqual([unwoundDate, unwoundDate28YearsAgo].yearSpan, 28)
   }
 }

--- a/Tests/SiteTests/PartialDateTests.swift
+++ b/Tests/SiteTests/PartialDateTests.swift
@@ -126,23 +126,69 @@ final class PartialDateTests: XCTestCase {
     let date1 = PartialDate(year: 1995, month: 12, day: 31)
     let date2 = PartialDate(year: 1997)
     let unknownDate = PartialDate()
-    let unwoundDate = PartialDate(year: 1995, month: 4, day: 1)
-    let unwoundDate28YearsAgo = PartialDate(year: 2023, month: 5, day: 26)
 
     XCTAssertEqual([date1].yearSpan, 1)
     XCTAssertEqual([date2].yearSpan, 1)
     XCTAssertEqual([unknownDate].yearSpan, 1)
 
-    XCTAssertEqual([date1, date2].yearSpan, 1)
+    XCTAssertEqual([date1, date2].yearSpan, 2)
     XCTAssertEqual([date1, date1].yearSpan, 1)
     XCTAssertEqual([date2, date2].yearSpan, 1)
 
     XCTAssertEqual([unknownDate, unknownDate].yearSpan, 1)
     XCTAssertEqual([unknownDate, date1].yearSpan, 1)
-    XCTAssertEqual([unknownDate, date1, date2].yearSpan, 1)
+    XCTAssertEqual([unknownDate, date1, date2].yearSpan, 2)
 
     XCTAssertEqual([PartialDate]().yearSpan, 0)
 
+    let unwoundDate = PartialDate(year: 1995, month: 4, day: 1)
+    let unwoundDate28YearsAgo = PartialDate(year: 2023, month: 5, day: 26)
     XCTAssertEqual([unwoundDate, unwoundDate28YearsAgo].yearSpan, 28)
+
+    let unwoundLast = PartialDate(year: 2023, month: 2, day: 8)
+    XCTAssertEqual([unwoundDate, unwoundLast].yearSpan, 27)
+
+    let miloFirst = PartialDate(year: 1993, month: 2, day: 13)
+    let miloLast = PartialDate(year: 1994, month: 5, day: 13)
+    XCTAssertEqual([miloFirst, miloLast].yearSpan, 2)
+
+    let jumpknuckleFirst = PartialDate(year: 1993, month: 2, day: 13)
+    let jumpknuckleLast = PartialDate(year: 1994, month: 12, day: 28)
+    XCTAssertEqual([jumpknuckleFirst, jumpknuckleLast].yearSpan, 2)
+
+    let posterchildrenFirst = PartialDate(year: 1989, month: 1, day: 17)
+    let posterchildrenLast = PartialDate(year: 2016, month: 10, day: 16)
+    XCTAssertEqual([unknownDate, posterchildrenFirst, posterchildrenLast].yearSpan, 27)
+
+    let humFirst = PartialDate(year: 1991, month: 11, day: 23)
+    let humLast = PartialDate(year: 2015, month: 9, day: 18)
+    XCTAssertEqual([humFirst, humLast].yearSpan, 23)
+
+    let initialDate = PartialDate(year: 2023, month: 2, day: 6)
+    let nextDay = PartialDate(year: 2023, month: 2, day: 7)
+    let nextMonth = PartialDate(year: 2023, month: 3, day: 1)
+    let nextMonthToTheDay = PartialDate(year: 2023, month: 3, day: 6)
+    let almostNextYear = PartialDate(year: 2023, month: 12, day: 15)
+    let yearJustChanged = PartialDate(year: 2024, month: 1, day: 1)
+    let almostAYearLater = PartialDate(year: 2024, month: 2, day: 5)
+    let oneYearToTheDayLater = PartialDate(year: 2024, month: 2, day: 6)
+    let oneYearAndOneDayLater = PartialDate(year: 2024, month: 2, day: 7)
+    let twoYearsToTheDayLater = PartialDate(year: 2025, month: 2, day: 6)
+    let twoYearsAndOneDayLater = PartialDate(year: 2025, month: 2, day: 7)
+    let threeYearsToTheDayLater = PartialDate(year: 2026, month: 2, day: 6)
+    let threeYearsAndOneDayLater = PartialDate(year: 2026, month: 2, day: 7)
+
+    XCTAssertEqual([initialDate, nextDay].yearSpan, 1)
+    XCTAssertEqual([initialDate, nextMonth].yearSpan, 1)
+    XCTAssertEqual([initialDate, nextMonthToTheDay].yearSpan, 1)
+    XCTAssertEqual([initialDate, almostNextYear].yearSpan, 1)
+    XCTAssertEqual([initialDate, yearJustChanged].yearSpan, 1)
+    XCTAssertEqual([initialDate, almostAYearLater].yearSpan, 1)
+    XCTAssertEqual([initialDate, oneYearToTheDayLater].yearSpan, 1)
+    XCTAssertEqual([initialDate, oneYearAndOneDayLater].yearSpan, 2)
+    XCTAssertEqual([initialDate, twoYearsToTheDayLater].yearSpan, 2)
+    XCTAssertEqual([initialDate, twoYearsAndOneDayLater].yearSpan, 2)
+    XCTAssertEqual([initialDate, threeYearsToTheDayLater].yearSpan, 3)
+    XCTAssertEqual([initialDate, threeYearsAndOneDayLater].yearSpan, 3)
   }
 }


### PR DESCRIPTION
- Calendar.dateComponents(components:from:to) to the rescue!
- Fixes #313