### PR TITLE
Add Locatable protocol

### DIFF
--- a/Sources/Site/Music/UI/LocationMap.swift
+++ b/Sources/Site/Music/UI/LocationMap.swift
@@ -22,10 +22,10 @@ struct LocationMap: View {
     ZStack {
       if let placemark {
         Map(
-          coordinateRegion: .constant(placemark.coordinateRegion),
+          coordinateRegion: .constant(placemark.region),
           interactionModes: MapInteractionModes(), annotationItems: [placemark]
         ) { placemark in
-          MapMarker(coordinate: placemark.coordinate)
+          MapMarker(coordinate: placemark.center)
         }
         .onTapGesture {
           MKMapItem(placemark: MKPlacemark(placemark: placemark)).openInMaps()

--- a/Sources/Site/Utility/Locatable.swift
+++ b/Sources/Site/Utility/Locatable.swift
@@ -1,0 +1,22 @@
+//
+//  Locatable.swift
+//
+//
+//  Created by Greg Bolsinga on 5/31/23.
+//
+
+import CoreLocation
+import MapKit
+
+protocol Locatable {
+  var center: CLLocationCoordinate2D { get }
+  var radius: CLLocationDistance { get }
+}
+
+extension Locatable {
+  var region: MKCoordinateRegion {
+    let radius = radius
+    return MKCoordinateRegion(
+      center: self.center, latitudinalMeters: radius, longitudinalMeters: radius)
+  }
+}

--- a/Sources/Site/Utility/Placemark+Geometry.swift
+++ b/Sources/Site/Utility/Placemark+Geometry.swift
@@ -8,19 +8,13 @@
 import CoreLocation
 import MapKit
 
-extension CLPlacemark {
-  var coordinate: CLLocationCoordinate2D {
+extension CLPlacemark: Locatable {
+  var center: CLLocationCoordinate2D {
     self.location?.coordinate ?? kCLLocationCoordinate2DInvalid
   }
 
-  internal var radius: CLLocationDistance {
+  var radius: CLLocationDistance {
     guard let circularRegion = self.region as? CLCircularRegion else { return 100.0 }  // meters
     return circularRegion.radius
-  }
-
-  var coordinateRegion: MKCoordinateRegion {
-    let radius = radius
-    return MKCoordinateRegion(
-      center: self.coordinate, latitudinalMeters: radius, longitudinalMeters: radius)
   }
 }


### PR DESCRIPTION
- It has an extension to calculate the MKCoordinateRegion.
- This is necessary since it is not possible (?!?) to create a hand rolled CLPlacemark for tests that has a center and a region.
- Make CLPlacemark conform to Locatable, and have LocationMap use the Locatable interface