### PR TITLE
Save NavigationPath to SceneStorage.

### DIFF
--- a/Sources/Site/Music/ArchivePath.swift
+++ b/Sources/Site/Music/ArchivePath.swift
@@ -13,3 +13,36 @@ public enum ArchivePath: Hashable {
   case artist(Artist.ID)
   case year(Annum)
 }
+
+extension ArchivePath: Codable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.formatted(.json))
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    try self = ArchivePath(container.decode(String.self))
+  }
+}
+
+extension Array where Element == ArchivePath {
+  var jsonData: Data? {
+    get {
+      let data = try? JSONEncoder().encode(self)
+      if let jsonString = String(data: data!, encoding: .utf8) {
+        print("encode: " + jsonString)
+      }
+      return data
+    }
+    set {
+      guard let data = newValue,
+        let array = try? JSONDecoder().decode(Self.self, from: data)
+      else { return }
+      if let jsonString = String(data: data, encoding: .utf8) {
+        print("decode: " + jsonString)
+      }
+      self = array
+    }
+  }
+}


### PR DESCRIPTION
This is a little tricky. When the List selection changes, it will reset the NavigationStack navigationPath. So when restoring state at launch in .task, if the selectedCategory and navigationPath both change, the navigationPath will be lost. The workaround is to hold onto the pending navigationPath, and set it after the selectedCategory has changed. Then forget about the pending navigationPath. Fixes #246