### PR TITLE
Allow ArchivePath to format to urlPath

### DIFF
--- a/Sources/Site/Music/Annum+FormatStyle.swift
+++ b/Sources/Site/Music/Annum+FormatStyle.swift
@@ -12,7 +12,7 @@ extension Annum {
     public enum Style: Codable, Equatable, Hashable {
       case year  // 1989 / "Year Unknown"
       case json  // 1989 / unknown
-      case pathAndFragment  // 1989 / other
+      case urlPath  // 1989 / other
     }
 
     let style: Style
@@ -47,7 +47,7 @@ extension Annum.FormatStyle: Foundation.FormatStyle {
         return unknownLocalized
       case .json:
         return Annum.FormatStyle.unknown
-      case .pathAndFragment:
+      case .urlPath:
         return Annum.FormatStyle.other
       }
     }
@@ -68,7 +68,7 @@ extension Annum {
 extension FormatStyle where Self == Annum.FormatStyle {
   public static var year: Self { .init(.year) }
   public static var json: Self { .init(.json) }
-  public static var pathAndFragment: Self { .init(.pathAndFragment) }
+  public static var urlPath: Self { .init(.urlPath) }
 
   static func annum(style: Annum.FormatStyle.Style = .year) -> Self {
     .init(style)

--- a/Sources/Site/Music/ArchivePath+FormatStyle.swift
+++ b/Sources/Site/Music/ArchivePath+FormatStyle.swift
@@ -32,6 +32,7 @@ extension ArchivePath {
   public struct FormatStyle: Codable, Equatable, Hashable {
     public enum Style: Codable, Equatable, Hashable {
       case json
+      case urlPath
     }
 
     let style: Style
@@ -48,19 +49,33 @@ extension ArchivePath {
 
 extension ArchivePath.FormatStyle: Foundation.FormatStyle {
   public func format(_ value: ArchivePath) -> String {
-    value.prefix
-      + {
-        switch value {
-        case .show(let iD):
-          return iD
-        case .venue(let iD):
-          return iD
-        case .artist(let iD):
-          return iD
-        case .year(let annum):
-          return annum.formatted(.json)
-        }
-      }()
+    switch style {
+    case .json:
+      return value.prefix
+        + {
+          switch value {
+          case .show(let iD):
+            return iD
+          case .venue(let iD):
+            return iD
+          case .artist(let iD):
+            return iD
+          case .year(let annum):
+            return annum.formatted(.json)
+          }
+        }()
+    case .urlPath:
+      switch value {
+      case .show(let iD):
+        return "/dates/\(iD).html"
+      case .venue(let iD):
+        return "/venues/\(iD).html"
+      case .artist(let iD):
+        return "/bands/\(iD).html"
+      case .year(let annum):
+        return "/dates/\(annum.formatted(.urlPath)).html"
+      }
+    }
   }
 }
 
@@ -77,6 +92,7 @@ extension ArchivePath {
 
 extension FormatStyle where Self == ArchivePath.FormatStyle {
   public static var json: Self { .init(.json) }
+  public static var urlPath: Self { .init(.urlPath) }
 
   static func archivePath(style: ArchivePath.FormatStyle.Style = .json) -> Self {
     .init(style)

--- a/Tests/SiteTests/AnnumTests.swift
+++ b/Tests/SiteTests/AnnumTests.swift
@@ -14,12 +14,12 @@ final class AnnumTests: XCTestCase {
     XCTAssertEqual(Annum.year(1989).formatted(), "1989")
     XCTAssertEqual(Annum.year(1989).formatted(.year), "1989")
     XCTAssertEqual(Annum.year(1989).formatted(.json), "1989")
-    XCTAssertEqual(Annum.year(1989).formatted(.pathAndFragment), "1989")
+    XCTAssertEqual(Annum.year(1989).formatted(.urlPath), "1989")
 
     XCTAssertEqual(Annum.unknown.formatted(), "Year Unknown")
     XCTAssertEqual(Annum.unknown.formatted(.year), "Year Unknown")
     XCTAssertEqual(Annum.unknown.formatted(.json), "unknown")
-    XCTAssertEqual(Annum.unknown.formatted(.pathAndFragment), "other")
+    XCTAssertEqual(Annum.unknown.formatted(.urlPath), "other")
   }
 
   func testParse() throws {

--- a/Tests/SiteTests/ArchivePathTests.swift
+++ b/Tests/SiteTests/ArchivePathTests.swift
@@ -18,6 +18,17 @@ final class ArchivePathTests: XCTestCase {
     XCTAssertEqual(ArchivePath.year(Annum.unknown).formatted(), "y-unknown")
   }
 
+  func testPathAndFragmentFormat() throws {
+    XCTAssertEqual(
+      ArchivePath.show("someIdentifier").formatted(.urlPath), "/dates/someIdentifier.html")
+    XCTAssertEqual(
+      ArchivePath.venue("someIdentifier").formatted(.urlPath), "/venues/someIdentifier.html")
+    XCTAssertEqual(
+      ArchivePath.artist("someIdentifier").formatted(.urlPath), "/bands/someIdentifier.html")
+    XCTAssertEqual(ArchivePath.year(Annum.year(1989)).formatted(.urlPath), "/dates/1989.html")
+    XCTAssertEqual(ArchivePath.year(Annum.unknown).formatted(.urlPath), "/dates/other.html")
+  }
+
   func testParse() throws {
     XCTAssertEqual(try ArchivePath("y-1989"), ArchivePath.year(Annum.year(1989)))
     XCTAssertEqual(try ArchivePath("y-unknown"), ArchivePath.year(Annum.unknown))


### PR DESCRIPTION
- rename previous `pathAndFragment` to `urlPath` too since the URL format no longer has a fragment.