### PR TITLE
Add ArchiveNavigation.navigate(to) for ArchiveCategory and ArchivePath

### DIFF
--- a/Sources/Site/Music/UI/ArchiveNavigation.swift
+++ b/Sources/Site/Music/UI/ArchiveNavigation.swift
@@ -45,4 +45,12 @@ final class ArchiveNavigation: ObservableObject {
       self.pendingNavigationPath = nil
     }
   }
+
+  func navigate(to path: ArchivePath) {
+    navigationPath.append(path)
+  }
+
+  func navigate(to category: ArchiveCategory) {
+    selectedCategory = category
+  }
 }


### PR DESCRIPTION
- It just appends to the NavigationPath for simplicity (changing the category at the same time will lose the navigation path for as yet unknown reasons).