### PR TITLE
Use userInfo instead of typedPayload

### DIFF
--- a/Sources/Site/Music/ArchivePath.swift
+++ b/Sources/Site/Music/ArchivePath.swift
@@ -15,18 +15,14 @@ public enum ArchivePath: Hashable {
 }
 
 extension ArchivePath: Codable {
-  enum CodingKeys: String, CodingKey {
-    case json
-  }
-
   public func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.formatted(.json), forKey: .json)
+    var container = encoder.singleValueContainer()
+    try container.encode(self.formatted(.json))
   }
 
   public init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    self = try ArchivePath(container.decode(String.self, forKey: .json))
+    let container = try decoder.singleValueContainer()
+    try self = ArchivePath(container.decode(String.self))
   }
 }
 

--- a/Sources/Site/Music/UI/PathRestorableUserActivityModifier.swift
+++ b/Sources/Site/Music/UI/PathRestorableUserActivityModifier.swift
@@ -24,11 +24,7 @@ struct PathRestorableUserActivityModifier<T: PathRestorableUserActivity>: ViewMo
   func body(content: Content) -> some View {
     content
       .userActivity(ArchivePath.activityType) { userActivity in
-        do {
-          try userActivity.update(item, url: vault.createURL(for: item.archivePath))
-        } catch {
-          Logger.updateActivity.log("error: \(error, privacy: .public)")
-        }
+        userActivity.update(item, url: vault.createURL(for: item.archivePath))
       }
   }
 }

--- a/Tests/SiteTests/PathRestorableUserActivityTests.swift
+++ b/Tests/SiteTests/PathRestorableUserActivityTests.swift
@@ -15,7 +15,7 @@ final class PathRestorableUserActivityTests: XCTestCase {
 
     let item = Show(artists: [], date: PartialDate(), id: "1", venue: "1")
 
-    XCTAssertNoThrow(try userActivity.update(item, url: nil))
+    userActivity.update(item, url: nil)
 
     XCTAssertTrue(userActivity.isEligibleForHandoff)
 
@@ -35,7 +35,7 @@ final class PathRestorableUserActivityTests: XCTestCase {
 
     let item = Artist(id: "1", name: "name")
 
-    XCTAssertNoThrow(try userActivity.update(item, url: nil))
+    userActivity.update(item, url: nil)
 
     XCTAssertTrue(userActivity.isEligibleForHandoff)
 
@@ -55,7 +55,7 @@ final class PathRestorableUserActivityTests: XCTestCase {
 
     let item = Venue(id: "1", location: Location(city: "city", state: "st"), name: "name")
 
-    XCTAssertNoThrow(try userActivity.update(item, url: nil))
+    userActivity.update(item, url: nil)
 
     XCTAssertTrue(userActivity.isEligibleForHandoff)
 
@@ -75,7 +75,7 @@ final class PathRestorableUserActivityTests: XCTestCase {
 
     let item = Annum.year(1990)
 
-    XCTAssertNoThrow(try userActivity.update(item, url: nil))
+    userActivity.update(item, url: nil)
 
     XCTAssertTrue(userActivity.isEligibleForHandoff)
 
@@ -96,9 +96,37 @@ final class PathRestorableUserActivityTests: XCTestCase {
     let item = Show(artists: [], date: PartialDate(), id: "1", venue: "1")
     let url = URL(string: "https://www.example.com")!
 
-    XCTAssertNoThrow(try userActivity.update(item, url: url))
+    userActivity.update(item, url: url)
 
     XCTAssertTrue(userActivity.isEligibleForPublicIndexing)
     XCTAssertEqual(userActivity.webpageURL, url)
+  }
+
+  func test_decodeError_noUserInfo() throws {
+    let userActivity = NSUserActivity(activityType: "test-type")
+    userActivity.userInfo = nil
+
+    XCTAssertThrowsError(try userActivity.archivePath())
+  }
+
+  func test_decodeError_emptyUserInfo() throws {
+    let userActivity = NSUserActivity(activityType: "test-type")
+    userActivity.userInfo = [:]
+
+    XCTAssertThrowsError(try userActivity.archivePath())
+  }
+
+  func test_decodeError_wrongType() throws {
+    let userActivity = NSUserActivity(activityType: "test-type")
+    userActivity.userInfo = [NSUserActivity.archiveKey: 6]
+
+    XCTAssertThrowsError(try userActivity.archivePath())
+  }
+
+  func test_decode() throws {
+    let userActivity = NSUserActivity(activityType: "test-type")
+    userActivity.userInfo = [NSUserActivity.archiveKey: "y-1988"]
+
+    XCTAssertEqual(try userActivity.archivePath(), ArchivePath.year(Annum.year(1988)))
   }
 }


### PR DESCRIPTION
- This allows more detail to be logged when there is a failure, which for unknown reasons, still happens.
- ArchivePath no longer has a keyed Codable; it has the singleContainer again.
- Since typedPayload is no longer used for encoding, it no longer throws, and client code and tests can be updated to reflect that.