### PR TITLE
Pass Vault to NSUserActivity update

### DIFF
--- a/Sources/Site/Music/Annum+NSUserActivity.swift
+++ b/Sources/Site/Music/Annum+NSUserActivity.swift
@@ -9,7 +9,7 @@ import CoreSpotlight
 import Foundation
 
 extension Annum: PathRestorableUserActivity {
-  func updateActivity(_ userActivity: NSUserActivity) {
+  func updateActivity(_ userActivity: NSUserActivity, vault: Vault) {
     userActivity.isEligibleForHandoff = true
 
     userActivity.isEligibleForSearch = true

--- a/Sources/Site/Music/Artist+NSUserActivity.swift
+++ b/Sources/Site/Music/Artist+NSUserActivity.swift
@@ -9,7 +9,7 @@ import CoreSpotlight
 import Foundation
 
 extension Artist: PathRestorableUserActivity {
-  func updateActivity(_ userActivity: NSUserActivity) {
+  func updateActivity(_ userActivity: NSUserActivity, vault: Vault) {
     userActivity.isEligibleForHandoff = true
 
     userActivity.isEligibleForSearch = true

--- a/Sources/Site/Music/NSUserActivity+ArchivePath.swift
+++ b/Sources/Site/Music/NSUserActivity+ArchivePath.swift
@@ -22,20 +22,20 @@ extension NSUserActivity {
 
   static let archiveKey = "archive"
 
-  func update<T: PathRestorableUserActivity>(_ item: T, url: URL?) {
+  func update<T: PathRestorableUserActivity>(_ item: T, vault: Vault) {
     let archivePath = item.archivePath
 
     let identifier = archivePath.formatted(.json)
     Logger.updateActivity.log("advertise: \(identifier, privacy: .public)")
     self.targetContentIdentifier = identifier
 
-    if let url {
+    if let url = vault.createURL(for: archivePath) {
       Logger.updateActivity.log("web: \(url.absoluteString, privacy: .public)")
       self.isEligibleForPublicIndexing = true
       self.webpageURL = url
     }
 
-    item.updateActivity(self)
+    item.updateActivity(self, vault: vault)
 
     self.requiredUserInfoKeys = [NSUserActivity.archiveKey]
     self.addUserInfoEntries(from: [NSUserActivity.archiveKey: identifier])

--- a/Sources/Site/Music/Show+NSUserActivity.swift
+++ b/Sources/Site/Music/Show+NSUserActivity.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Show: PathRestorableUserActivity {
-  func updateActivity(_ userActivity: NSUserActivity) {
+  func updateActivity(_ userActivity: NSUserActivity, vault: Vault) {
     userActivity.isEligibleForHandoff = true
   }
 }

--- a/Sources/Site/Music/UI/PathRestorableUserActivityModifier.swift
+++ b/Sources/Site/Music/UI/PathRestorableUserActivityModifier.swift
@@ -13,7 +13,7 @@ extension ArchivePath {
 }
 
 protocol PathRestorableUserActivity: PathRestorable {
-  func updateActivity(_ userActivity: NSUserActivity)
+  func updateActivity(_ userActivity: NSUserActivity, vault: Vault)
 }
 
 struct PathRestorableUserActivityModifier<T: PathRestorableUserActivity>: ViewModifier {
@@ -24,7 +24,7 @@ struct PathRestorableUserActivityModifier<T: PathRestorableUserActivity>: ViewMo
   func body(content: Content) -> some View {
     content
       .userActivity(ArchivePath.activityType) { userActivity in
-        userActivity.update(item, url: vault.createURL(for: item.archivePath))
+        userActivity.update(item, vault: vault)
       }
   }
 }

--- a/Sources/Site/Music/Vault+PreviewData.swift
+++ b/Sources/Site/Music/Vault+PreviewData.swift
@@ -39,6 +39,6 @@ extension Vault {
       timestamp: Date.now,
       venues: [venue])
 
-    return Vault(music: music)
+    return Vault(music: music, url: URL(string: "https://www.example.com"))
   }
 }

--- a/Sources/Site/Music/Venue+NSUserActivity.swift
+++ b/Sources/Site/Music/Venue+NSUserActivity.swift
@@ -9,7 +9,7 @@ import CoreSpotlight
 import Foundation
 
 extension Venue: PathRestorableUserActivity {
-  func updateActivity(_ userActivity: NSUserActivity) {
+  func updateActivity(_ userActivity: NSUserActivity, vault: Vault) {
     userActivity.isEligibleForHandoff = true
 
     userActivity.isEligibleForSearch = true

--- a/Tests/SiteTests/PathRestorableUserActivityTests.swift
+++ b/Tests/SiteTests/PathRestorableUserActivityTests.swift
@@ -10,12 +10,14 @@ import XCTest
 @testable import Site
 
 final class PathRestorableUserActivityTests: XCTestCase {
+  let vault = Vault.previewData
+
   func testShow() throws {
     let userActivity = NSUserActivity(activityType: "test-type")
 
     let item = Show(artists: [], date: PartialDate(), id: "1", venue: "1")
 
-    userActivity.update(item, url: nil)
+    userActivity.update(item, vault: vault)
 
     XCTAssertTrue(userActivity.isEligibleForHandoff)
 
@@ -24,8 +26,8 @@ final class PathRestorableUserActivityTests: XCTestCase {
     XCTAssertFalse(userActivity.isEligibleForSearch)
     XCTAssertNil(userActivity.contentAttributeSet)
 
-    XCTAssertFalse(userActivity.isEligibleForPublicIndexing)
-    XCTAssertNil(userActivity.webpageURL)
+    XCTAssertTrue(userActivity.isEligibleForPublicIndexing)
+    XCTAssertNotNil(userActivity.webpageURL)
 
     XCTAssertEqual(try userActivity.archivePath(), try ArchivePath("sh-1"))
 
@@ -37,7 +39,7 @@ final class PathRestorableUserActivityTests: XCTestCase {
 
     let item = Artist(id: "1", name: "name")
 
-    userActivity.update(item, url: nil)
+    userActivity.update(item, vault: vault)
 
     XCTAssertTrue(userActivity.isEligibleForHandoff)
 
@@ -46,8 +48,8 @@ final class PathRestorableUserActivityTests: XCTestCase {
     XCTAssertTrue(userActivity.isEligibleForSearch)
     XCTAssertNotNil(userActivity.contentAttributeSet)
 
-    XCTAssertFalse(userActivity.isEligibleForPublicIndexing)
-    XCTAssertNil(userActivity.webpageURL)
+    XCTAssertTrue(userActivity.isEligibleForPublicIndexing)
+    XCTAssertNotNil(userActivity.webpageURL)
 
     XCTAssertEqual(try userActivity.archivePath(), try ArchivePath("ar-1"))
   }
@@ -57,7 +59,7 @@ final class PathRestorableUserActivityTests: XCTestCase {
 
     let item = Venue(id: "1", location: Location(city: "city", state: "st"), name: "name")
 
-    userActivity.update(item, url: nil)
+    userActivity.update(item, vault: vault)
 
     XCTAssertTrue(userActivity.isEligibleForHandoff)
 
@@ -66,8 +68,8 @@ final class PathRestorableUserActivityTests: XCTestCase {
     XCTAssertTrue(userActivity.isEligibleForSearch)
     XCTAssertNotNil(userActivity.contentAttributeSet)
 
-    XCTAssertFalse(userActivity.isEligibleForPublicIndexing)
-    XCTAssertNil(userActivity.webpageURL)
+    XCTAssertTrue(userActivity.isEligibleForPublicIndexing)
+    XCTAssertNotNil(userActivity.webpageURL)
 
     XCTAssertEqual(try userActivity.archivePath(), try ArchivePath("v-1"))
   }
@@ -77,7 +79,7 @@ final class PathRestorableUserActivityTests: XCTestCase {
 
     let item = Annum.year(1990)
 
-    userActivity.update(item, url: nil)
+    userActivity.update(item, vault: vault)
 
     XCTAssertTrue(userActivity.isEligibleForHandoff)
 
@@ -86,8 +88,8 @@ final class PathRestorableUserActivityTests: XCTestCase {
     XCTAssertTrue(userActivity.isEligibleForSearch)
     XCTAssertNotNil(userActivity.contentAttributeSet)
 
-    XCTAssertFalse(userActivity.isEligibleForPublicIndexing)
-    XCTAssertNil(userActivity.webpageURL)
+    XCTAssertTrue(userActivity.isEligibleForPublicIndexing)
+    XCTAssertNotNil(userActivity.webpageURL)
 
     XCTAssertEqual(try userActivity.archivePath(), try ArchivePath("y-1990"))
   }
@@ -96,9 +98,9 @@ final class PathRestorableUserActivityTests: XCTestCase {
     let userActivity = NSUserActivity(activityType: "test-type")
 
     let item = Show(artists: [], date: PartialDate(), id: "1", venue: "1")
-    let url = URL(string: "https://www.example.com")!
+    let url = URL(string: "https://www.example.com/dates/1.html")!
 
-    userActivity.update(item, url: url)
+    userActivity.update(item, vault: vault)
 
     XCTAssertTrue(userActivity.isEligibleForPublicIndexing)
     XCTAssertEqual(userActivity.webpageURL, url)


### PR DESCRIPTION
- Vault is necessary to describe some upcoming NSUserActivity.