### PR TITLE
Annotate VaultModel with @MainActor

### DIFF
--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -13,7 +13,7 @@ extension Logger {
   static let vaultModel = Logger(category: "vaultModel")
 }
 
-public final class VaultModel: ObservableObject {
+@MainActor public final class VaultModel: ObservableObject {
   let url: URL
 
   @Published var vault: Vault?


### PR DESCRIPTION
- Eliminates: "[SwiftUI] Publishing changes from background threads is not allowed; make sure to publish values from the main thread (via operators like receive(on:)) on model updates." message.