### PR TITLE
Add a tool to create stable venue IDs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
     .library(name: "Site", targets: ["Site"]),
     .executable(name: "site_tool", targets: ["site_tool"]),
     .executable(name: "site_associated_domains", targets: ["site_associated_domains"]),
+    .executable(name: "stable_ids", targets: ["stable_ids"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
@@ -29,6 +30,12 @@ let package = Package(
     .executableTarget(
       name: "site_associated_domains",
       dependencies: [
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      ]),
+    .executableTarget(
+      name: "stable_ids",
+      dependencies: [
+        .byName(name: "Site"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ]),
   ]

--- a/Sources/stable_ids/Program.swift
+++ b/Sources/stable_ids/Program.swift
@@ -1,0 +1,60 @@
+//
+//  Program.swift
+//
+//  Created by Greg Bolsinga on 8/2/23.
+//
+
+import ArgumentParser
+import Foundation
+import Site
+
+@main
+struct Program: AsyncParsableCommand {
+  enum URLError: Error {
+    case notURLString(String)
+  }
+
+  @Argument(
+    help:
+      "The root URL for the json files.",
+    transform: ({
+      let url = URL(string: $0)
+      guard let url else { throw URLError.notURLString($0) }
+      return url
+    })
+  )
+  var rootURL: URL
+
+  @Argument(
+    help: "The file URL for the original raw file.",
+    transform: ({
+      return URL(filePath: $0, directoryHint: .notDirectory)
+    })
+  )
+  var rawFileInputURL: URL
+
+  @Argument(
+    help: "The file URL for the output raw file with IDs.",
+    transform: ({
+      return URL(filePath: $0, directoryHint: .notDirectory)
+    })
+  )
+  var rawFileOutputURL: URL
+
+  func run() async throws {
+    let vault = try await Vault.load(url: rootURL.appending(path: "music.json"))
+    let lookup = vault.music.venues.reduce(into: [:]) { $0[$1.name] = $1.id }  // name : ID
+
+    let data = try String(contentsOf: rawFileInputURL, encoding: .utf8)
+    let lines = data.components(separatedBy: .newlines)
+
+    let stableLines = lines.filter { !$0.isEmpty }.map {
+      let name = $0.components(separatedBy: "*")[0]
+      guard let id = lookup[name] else { fatalError("bad line: \($0)") }
+      return "\(id)*\($0)"
+    }
+
+    let raw = stableLines.joined(separator: "\n").appending("\n")
+    try raw.write(to: rawFileOutputURL, atomically: true, encoding: .utf8)
+  }
+}


### PR DESCRIPTION
- Basically just encode the ID into the raw data. That way it will not change. It requires careful editing when adding a new venue.

Steps:
- Read the JSON from the web to get the current venue IDs.
- Read the current raw venue data file used by web_generator.
- Look up the venue name and prepend the ID to the raw venue data.
- Update the web_generator code to require the manual venue ID, and to throw if any duplicate IDs are encountered.

See #233