### PR TITLE
Convert tool to create stable show IDs

### DIFF
--- a/Sources/stable_ids/Program.swift
+++ b/Sources/stable_ids/Program.swift
@@ -8,6 +8,32 @@ import ArgumentParser
 import Foundation
 import Site
 
+extension PartialDate {
+  var raw: String {
+    return "\(month ?? 0)-\(day ?? 0)-\(year ?? 1900)"
+  }
+}
+
+extension Show {
+  func rawKey(_ vault: Vault) -> String {
+    guard
+      let rawArtists = try? vault.lookup.artistsForShow(self).map({ $0.name }).joined(
+        separator: "|")
+    else { fatalError("error looking up artists") }
+    guard let venueName = try? vault.lookup.venueForShow(self).name else {
+      fatalError("error getting venue name")
+    }
+    return "\(date.raw)^\(rawArtists)^\(venueName)"
+  }
+}
+
+extension String {
+  var rawKey: String {
+    let parts = self.components(separatedBy: "^")
+    return "\(parts[0])^\(parts[1])^\(parts[2])"
+  }
+}
+
 @main
 struct Program: AsyncParsableCommand {
   enum URLError: Error {
@@ -43,15 +69,15 @@ struct Program: AsyncParsableCommand {
 
   func run() async throws {
     let vault = try await Vault.load(url: rootURL.appending(path: "music.json"))
-    let lookup = vault.music.venues.reduce(into: [:]) { $0[$1.name] = $1.id }  // name : ID
+    let lookup = vault.music.shows.reduce(into: [:]) { $0[$1.rawKey(vault)] = $1.id }  // raw : ID
 
     let data = try String(contentsOf: rawFileInputURL, encoding: .utf8)
     let lines = data.components(separatedBy: .newlines)
 
     let stableLines = lines.filter { !$0.isEmpty }.map {
-      let name = $0.components(separatedBy: "*")[0]
-      guard let id = lookup[name] else { fatalError("bad line: \($0)") }
-      return "\(id)*\($0)"
+      let key = $0.rawKey
+      guard let id = lookup[key] else { fatalError("bad line: \($0)") }
+      return "\(id)^\($0)"
     }
 
     let raw = stableLines.joined(separator: "\n").appending("\n")


### PR DESCRIPTION
- Basically encode the show ID into the raw data used by web_generator.
- Read the JSON to get the latest IDs.
- Read the raw show data used by web_generator
- Look up the raw data's show ID using "date^artists^venue" as a "key"
- write out this new raw data
- need to update web_generator to read this new raw data format.

See #233