### PR TITLE
mark private parts appropriately

### DIFF
--- a/Sources/Site/Music/NSUserActivity+ArchivePath.swift
+++ b/Sources/Site/Music/NSUserActivity+ArchivePath.swift
@@ -14,13 +14,13 @@ extension Logger {
 }
 
 extension NSUserActivity {
-  enum DecodeError: Error {
+  private enum DecodeError: Error {
     case noUserInfo
     case noArchiveKey
     case archiveKeyIncorrectType
   }
 
-  static let archiveKey = "archive"
+  private static let archiveKey = "archive"
 
   func update<T: PathRestorableUserActivity>(_ item: T, vault: Vault) {
     let archivePath = item.archivePath

--- a/Sources/Site/Music/NSUserActivity+ArchivePath.swift
+++ b/Sources/Site/Music/NSUserActivity+ArchivePath.swift
@@ -14,13 +14,13 @@ extension Logger {
 }
 
 extension NSUserActivity {
-  private enum DecodeError: Error {
+  internal enum DecodeError: Error {
     case noUserInfo
     case noArchiveKey
     case archiveKeyIncorrectType
   }
 
-  private static let archiveKey = "archive"
+  internal static let archiveKey = "archive"
 
   func update<T: PathRestorableUserActivity>(_ item: T, vault: Vault) {
     let archivePath = item.archivePath

--- a/Sources/Site/Music/NSUserActivity+ArchivePath.swift
+++ b/Sources/Site/Music/NSUserActivity+ArchivePath.swift
@@ -14,13 +14,13 @@ extension Logger {
 }
 
 extension NSUserActivity {
-  internal enum DecodeError: Error {
+  private enum DecodeError: Error {
     case noUserInfo
     case noArchiveKey
     case archiveKeyIncorrectType
   }
 
-  internal static let archiveKey = "archive"
+  internal static let archivePathKey = "archivePath"
 
   func update<T: PathRestorableUserActivity>(_ item: T, vault: Vault) {
     let archivePath = item.archivePath
@@ -37,8 +37,8 @@ extension NSUserActivity {
 
     item.updateActivity(self, vault: vault)
 
-    self.requiredUserInfoKeys = [NSUserActivity.archiveKey]
-    self.addUserInfoEntries(from: [NSUserActivity.archiveKey: identifier])
+    self.requiredUserInfoKeys = [NSUserActivity.archivePathKey]
+    self.addUserInfoEntries(from: [NSUserActivity.archivePathKey: identifier])
 
     self.expirationDate = .now + (60 * 60 * 24)
   }
@@ -51,13 +51,13 @@ extension NSUserActivity {
       throw DecodeError.noUserInfo
     }
 
-    guard let value = userInfo[NSUserActivity.archiveKey] else {
-      Logger.decodeActivity.log("no archiveKey")
+    guard let value = userInfo[NSUserActivity.archivePathKey] else {
+      Logger.decodeActivity.log("no archivePathKey")
       throw DecodeError.noArchiveKey
     }
 
     guard let archiveString = value as? String else {
-      Logger.decodeActivity.log("archiveKey not String")
+      Logger.decodeActivity.log("archivePathKey not String")
       throw DecodeError.archiveKeyIncorrectType
     }
 

--- a/Tests/SiteTests/PathRestorableUserActivityTests.swift
+++ b/Tests/SiteTests/PathRestorableUserActivityTests.swift
@@ -122,14 +122,14 @@ final class PathRestorableUserActivityTests: XCTestCase {
 
   func test_decodeError_wrongType() throws {
     let userActivity = NSUserActivity(activityType: "test-type")
-    userActivity.userInfo = [NSUserActivity.archiveKey: 6]
+    userActivity.userInfo = [NSUserActivity.archivePathKey: 6]
 
     XCTAssertThrowsError(try userActivity.archivePath())
   }
 
   func test_decode() throws {
     let userActivity = NSUserActivity(activityType: "test-type")
-    userActivity.userInfo = [NSUserActivity.archiveKey: "y-1988"]
+    userActivity.userInfo = [NSUserActivity.archivePathKey: "y-1988"]
 
     XCTAssertEqual(try userActivity.archivePath(), ArchivePath.year(Annum.year(1988)))
   }


### PR DESCRIPTION
- this allows other extensions to use the same names.