### PR TITLE
Revert "Clarify what is being navigated to (#494)"

### DIFF
--- a/Sources/Site/Music/UI/ArchiveCategorySplit.swift
+++ b/Sources/Site/Music/UI/ArchiveCategorySplit.swift
@@ -65,7 +65,7 @@ struct ArchiveCategorySplit: View {
     .environment(\.vault, vault)
     .onContinueUserActivity(ArchivePath.activityType) { userActivity in
       do {
-        archiveNavigation.navigate(toPath: try userActivity.archivePath())
+        archiveNavigation.navigate(to: try userActivity.archivePath())
       } catch {
         Logger.decodeActivity.log("error: \(error, privacy: .public)")
       }
@@ -74,7 +74,7 @@ struct ArchiveCategorySplit: View {
       Logger.link.log("url: \(url.absoluteString, privacy: .public)")
       do {
         let archivePath = try ArchivePath(url)
-        archiveNavigation.navigate(toPath: archivePath)
+        archiveNavigation.navigate(to: archivePath)
       } catch {
         Logger.link.log("error: \(error, privacy: .public)")
       }

--- a/Sources/Site/Music/UI/ArchiveNavigation.swift
+++ b/Sources/Site/Music/UI/ArchiveNavigation.swift
@@ -49,7 +49,7 @@ final class ArchiveNavigation: ObservableObject {
     }
   }
 
-  func navigate(toPath path: ArchivePath) {
+  func navigate(to path: ArchivePath) {
     guard path != navigationPath.last else {
       Logger.archive.log("already presented: \(path.formatted(), privacy: .public)")
       return
@@ -58,7 +58,7 @@ final class ArchiveNavigation: ObservableObject {
     navigationPath.append(path)
   }
 
-  func navigate(toCategory category: ArchiveCategory?) {
+  func navigate(to category: ArchiveCategory?) {
     Logger.archive.log("nav to category: \(category?.rawValue ?? "nil", privacy: .public)")
     selectedCategory = category
   }

--- a/Tests/SiteTests/ArchiveNavigationTests.swift
+++ b/Tests/SiteTests/ArchiveNavigationTests.swift
@@ -15,11 +15,11 @@ final class ArchiveNavigationTests: XCTestCase {
     XCTAssertNil(ar.selectedCategory)
     XCTAssertTrue(ar.navigationPath.isEmpty)
 
-    ar.navigate(toCategory: .today)
+    ar.navigate(to: .today)
     XCTAssertEqual(ar.selectedCategory, .today)
     XCTAssertTrue(ar.navigationPath.isEmpty)
 
-    ar.navigate(toCategory: nil)
+    ar.navigate(to: nil)
     XCTAssertNil(ar.selectedCategory)
     XCTAssertTrue(ar.navigationPath.isEmpty)
   }
@@ -29,7 +29,7 @@ final class ArchiveNavigationTests: XCTestCase {
     XCTAssertNil(ar.selectedCategory)
     XCTAssertTrue(ar.navigationPath.isEmpty)
 
-    ar.navigate(toPath: ArchivePath.artist("id"))
+    ar.navigate(to: ArchivePath.artist("id"))
     XCTAssertNil(ar.selectedCategory)
     XCTAssertEqual(ar.navigationPath.count, 1)
 
@@ -39,13 +39,13 @@ final class ArchiveNavigationTests: XCTestCase {
 
   func testNavigateToArchivePath_noDoubles() throws {
     let ar = ArchiveNavigation()
-    ar.navigate(toPath: ArchivePath.artist("id"))
+    ar.navigate(to: ArchivePath.artist("id"))
     XCTAssertEqual(ar.navigationPath.count, 1)
 
-    ar.navigate(toPath: ArchivePath.artist("id"))
+    ar.navigate(to: ArchivePath.artist("id"))
     XCTAssertEqual(ar.navigationPath.count, 1)
 
-    ar.navigate(toPath: ArchivePath.artist("id-1"))
+    ar.navigate(to: ArchivePath.artist("id-1"))
     XCTAssertEqual(ar.navigationPath.count, 2)
   }
 


### PR DESCRIPTION
This reverts commit 329f67c44f96a7d4a23bedd98b36a206d797bca7.

- no longer necessary after #499