### PR TITLE
Add ValidationError.invalidPrefix when parsing URLs into ArchivePath

### DIFF
--- a/Sources/Site/Music/ArchivePath+ParseableFormatStyle.swift
+++ b/Sources/Site/Music/ArchivePath+ParseableFormatStyle.swift
@@ -71,6 +71,7 @@ extension ArchivePath.FormatStyle {
       case filenameFormat
       case fileType
       case archiveType
+      case invalidPrefix
     }
 
     public init() {}
@@ -111,10 +112,19 @@ extension ArchivePath.FormatStyle {
 
       switch type {
       case "bands":
+        guard id.starts(with: ArchivePath.artistPrefix) else {
+          throw ValidationError.invalidPrefix
+        }
         return ArchivePath.artist(id)
       case "venues":
+        guard id.starts(with: ArchivePath.venuePrefix) else {
+          throw ValidationError.invalidPrefix
+        }
         return ArchivePath.venue(id)
       case "dates":
+        guard id.starts(with: ArchivePath.showPrefix) else {
+          throw ValidationError.invalidPrefix
+        }
         return ArchivePath.show(id)
       default:
         throw ValidationError.archiveType

--- a/Tests/SiteTests/ArchivePathTests.swift
+++ b/Tests/SiteTests/ArchivePathTests.swift
@@ -78,11 +78,26 @@ final class ArchivePathTests: XCTestCase {
       try ArchivePath(URL(string: "https://www.example.com/bands/ar852.html")!),
       ArchivePath.artist("ar852"))
     XCTAssertEqual(
-      try ArchivePath(URL(string: "https://www.example.com/venues/ar852.html")!),
-      ArchivePath.venue("ar852"))
+      try ArchivePath(URL(string: "https://www.example.com/venues/v852.html")!),
+      ArchivePath.venue("v852"))
     XCTAssertEqual(
-      try ArchivePath(URL(string: "https://www.example.com/dates/ar852.html")!),
-      ArchivePath.show("ar852"))
+      try ArchivePath(URL(string: "https://www.example.com/dates/sh852.html")!),
+      ArchivePath.show("sh852"))
+
+    XCTAssertThrowsError(
+      try ArchivePath(URL(string: "https://www.example.com/bands/v852.html")!))
+    XCTAssertThrowsError(
+      try ArchivePath(URL(string: "https://www.example.com/venues/ar852.html")!))
+    XCTAssertThrowsError(
+      try ArchivePath(URL(string: "https://www.example.com/dates/ar852.html")!))
+
+    XCTAssertThrowsError(
+      try ArchivePath(URL(string: "https://www.example.com/bands/status.html")!))
+    XCTAssertThrowsError(
+      try ArchivePath(URL(string: "https://www.example.com/venues/stats.html")!))
+    XCTAssertThrowsError(
+      try ArchivePath(URL(string: "https://www.example.com/dates/stats.html")!))
+
     XCTAssertThrowsError(
       try ArchivePath(URL(string: "https://www.example.com/venues/L.html#ar852")!))
     XCTAssertThrowsError(try ArchivePath(URL(string: "https://www.example.com/venues/ar852")!))


### PR DESCRIPTION
- Fixes when Safari detects stats pages and allows users to open them in the app. It will now correctly throw from ArchivePath, and then correctly create the ArchiveCategory.