### PR TITLE
Rename vault variable for tests and previews

### DIFF
--- a/Sources/Site/Music/UI/AddressView.swift
+++ b/Sources/Site/Music/UI/AddressView.swift
@@ -24,9 +24,9 @@ struct AddressView: View {
 
 struct AddressView_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
-    AddressView(location: vault.venueDigests[0].venue.location)
+    AddressView(location: vaultPreview.venueDigests[0].venue.location)
 
     let locationWithoutOptionals = Location(city: "Charleston", state: "IL")
     AddressView(location: locationWithoutOptionals)

--- a/Sources/Site/Music/UI/ArchiveCategoryDetail.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryDetail.swift
@@ -50,36 +50,36 @@ struct ArchiveCategoryDetail: View {
 
 struct ArchiveCategoryDetail_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
     ArchiveCategoryDetail(
       category: .today, todayConcerts: .constant([]), venueSort: .constant(.alphabetical),
       artistSort: .constant(.alphabetical), isCategoryActive: .constant(true)
     )
-    .environment(\.vault, vault)
+    .environment(\.vault, vaultPreview)
 
     ArchiveCategoryDetail(
       category: .stats, todayConcerts: .constant([]), venueSort: .constant(.alphabetical),
       artistSort: .constant(.alphabetical), isCategoryActive: .constant(true)
     )
-    .environment(\.vault, vault)
+    .environment(\.vault, vaultPreview)
 
     ArchiveCategoryDetail(
       category: .shows, todayConcerts: .constant([]), venueSort: .constant(.alphabetical),
       artistSort: .constant(.alphabetical), isCategoryActive: .constant(true)
     )
-    .environment(\.vault, vault)
+    .environment(\.vault, vaultPreview)
 
     ArchiveCategoryDetail(
       category: .venues, todayConcerts: .constant([]), venueSort: .constant(.alphabetical),
       artistSort: .constant(.alphabetical), isCategoryActive: .constant(true)
     )
-    .environment(\.vault, vault)
+    .environment(\.vault, vaultPreview)
 
     ArchiveCategoryDetail(
       category: .artists, todayConcerts: .constant([]), venueSort: .constant(.alphabetical),
       artistSort: .constant(.alphabetical), isCategoryActive: .constant(true)
     )
-    .environment(\.vault, vault)
+    .environment(\.vault, vaultPreview)
   }
 }

--- a/Sources/Site/Music/UI/ArtistBlurb.swift
+++ b/Sources/Site/Music/UI/ArtistBlurb.swift
@@ -26,18 +26,18 @@ struct ArtistBlurb: View {
 
 struct ArtistBlurbView_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
     NavigationStack {
-      ArtistBlurb(concert: vault.concerts[0])
+      ArtistBlurb(concert: vaultPreview.concerts[0])
     }
 
     NavigationStack {
-      ArtistBlurb(concert: vault.concerts[1])
+      ArtistBlurb(concert: vaultPreview.concerts[1])
     }
 
     NavigationStack {
-      ArtistBlurb(concert: vault.concerts[2])
+      ArtistBlurb(concert: vaultPreview.concerts[2])
     }
   }
 }

--- a/Sources/Site/Music/UI/ArtistDetail.swift
+++ b/Sources/Site/Music/UI/ArtistDetail.swift
@@ -75,16 +75,16 @@ struct ArtistDetail: View {
 
 struct ArtistDetail_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
     NavigationStack {
-      ArtistDetail(digest: vault.artistDigests[0])
-        .musicDestinations(vault)
+      ArtistDetail(digest: vaultPreview.artistDigests[0])
+        .musicDestinations(vaultPreview)
     }
 
     NavigationStack {
-      ArtistDetail(digest: vault.artistDigests[1])
-        .musicDestinations(vault)
+      ArtistDetail(digest: vaultPreview.artistDigests[1])
+        .musicDestinations(vaultPreview)
     }
   }
 }

--- a/Sources/Site/Music/UI/ArtistList.swift
+++ b/Sources/Site/Music/UI/ArtistList.swift
@@ -114,14 +114,14 @@ struct ArtistList: View {
 
 struct ArtistList_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
     NavigationStack {
       ArtistList(
-        artistDigests: vault.artistDigests, sectioner: vault.sectioner,
+        artistDigests: vaultPreview.artistDigests, sectioner: vaultPreview.sectioner,
         sort: .constant(.alphabetical)
       )
-      .musicDestinations(vault)
+      .musicDestinations(vaultPreview)
     }
   }
 }

--- a/Sources/Site/Music/UI/ConcertBlurb.swift
+++ b/Sources/Site/Music/UI/ConcertBlurb.swift
@@ -39,12 +39,12 @@ struct ConcertBlurb: View {
 
 struct ConcertBlurbView_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
-    ConcertBlurb(concert: vault.concerts[0])
+    ConcertBlurb(concert: vaultPreview.concerts[0])
 
-    ConcertBlurb(concert: vault.concerts[1])
+    ConcertBlurb(concert: vaultPreview.concerts[1])
 
-    ConcertBlurb(concert: vault.concerts[2])
+    ConcertBlurb(concert: vaultPreview.concerts[2])
   }
 }

--- a/Sources/Site/Music/UI/LibraryComparableList.swift
+++ b/Sources/Site/Music/UI/LibraryComparableList.swift
@@ -57,11 +57,11 @@ where T: LibraryComparable, T: Identifiable, T: Hashable, T.ID == String, T: Pat
 
 struct LibraryComparableList_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
     NavigationStack {
       LibraryComparableList(
-        items: vault.artistDigests,
+        items: vaultPreview.artistDigests,
         sectioner: LibrarySectioner(),
         itemContentView: { _ in
           Text(3.formatted(.number))
@@ -72,12 +72,12 @@ struct LibraryComparableList_Previews: PreviewProvider {
         searchString: .constant("")
       )
       .navigationTitle("Artists")
-      .musicDestinations(vault)
+      .musicDestinations(vaultPreview)
     }
 
     NavigationStack {
       LibraryComparableList(
-        items: vault.venueDigests,
+        items: vaultPreview.venueDigests,
         sectioner: LibrarySectioner(),
         itemContentView: { _ in
           EmptyView()
@@ -88,7 +88,7 @@ struct LibraryComparableList_Previews: PreviewProvider {
         searchString: .constant("")
       )
       .navigationTitle("Venues")
-      .musicDestinations(vault)
+      .musicDestinations(vaultPreview)
     }
   }
 }

--- a/Sources/Site/Music/UI/RankingList.swift
+++ b/Sources/Site/Music/UI/RankingList.swift
@@ -49,11 +49,11 @@ where T: LibraryComparable, T: Hashable, T: PathRestorable, R: Comparable, R: Ha
 
 struct RankingList_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
     NavigationStack {
       RankingList(
-        items: vault.artistDigests,
+        items: vaultPreview.artistDigests,
         rankingMapBuilder: { artists in
           return [Ranking(rank: .rank(1), value: 3): artists]
         },
@@ -67,12 +67,12 @@ struct RankingList_Previews: PreviewProvider {
         searchString: .constant("")
       )
       .navigationTitle("Artists")
-      .musicDestinations(vault)
+      .musicDestinations(vaultPreview)
     }
 
     NavigationStack {
       RankingList(
-        items: vault.venueDigests,
+        items: vaultPreview.venueDigests,
         rankingMapBuilder: { artists in
           return [Ranking(rank: .rank(1), value: 3): artists]
         },
@@ -83,7 +83,7 @@ struct RankingList_Previews: PreviewProvider {
         searchString: .constant("")
       )
       .navigationTitle("Venues")
-      .musicDestinations(vault)
+      .musicDestinations(vaultPreview)
     }
   }
 }

--- a/Sources/Site/Music/UI/ShowDetail.swift
+++ b/Sources/Site/Music/UI/ShowDetail.swift
@@ -75,24 +75,24 @@ struct ShowDetail: View {
 
 struct ShowDetail_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
     NavigationStack {
-      let concert = vault.concerts[0]
-      ShowDetail(concert: concert, url: concert.archivePath.url(using: vault.baseURL))
-        .musicDestinations(vault)
+      let concert = vaultPreview.concerts[0]
+      ShowDetail(concert: concert, url: concert.archivePath.url(using: vaultPreview.baseURL))
+        .musicDestinations(vaultPreview)
     }
 
     NavigationStack {
-      let concert = vault.concerts[1]
-      ShowDetail(concert: concert, url: concert.archivePath.url(using: vault.baseURL))
-        .musicDestinations(vault)
+      let concert = vaultPreview.concerts[1]
+      ShowDetail(concert: concert, url: concert.archivePath.url(using: vaultPreview.baseURL))
+        .musicDestinations(vaultPreview)
     }
 
     NavigationStack {
-      let concert = vault.concerts[2]
-      ShowDetail(concert: concert, url: concert.archivePath.url(using: vault.baseURL))
-        .musicDestinations(vault)
+      let concert = vaultPreview.concerts[2]
+      ShowDetail(concert: concert, url: concert.archivePath.url(using: vaultPreview.baseURL))
+        .musicDestinations(vaultPreview)
     }
   }
 }

--- a/Sources/Site/Music/UI/ShowYearList.swift
+++ b/Sources/Site/Music/UI/ShowYearList.swift
@@ -37,11 +37,11 @@ struct ShowYearList: View {
 
 struct ShowYearList_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
     NavigationStack {
-      ShowYearList(decadesMap: vault.lookup.decadesMap)
-        .musicDestinations(vault)
+      ShowYearList(decadesMap: vaultPreview.lookup.decadesMap)
+        .musicDestinations(vaultPreview)
     }
   }
 }

--- a/Sources/Site/Music/UI/TodayBlurb.swift
+++ b/Sources/Site/Music/UI/TodayBlurb.swift
@@ -41,12 +41,12 @@ struct TodayBlurb: View {
 
 struct TodayBlurb_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
-    TodayBlurb(concert: vault.concerts[0])
+    TodayBlurb(concert: vaultPreview.concerts[0])
 
-    TodayBlurb(concert: vault.concerts[1])
+    TodayBlurb(concert: vaultPreview.concerts[1])
 
-    TodayBlurb(concert: vault.concerts[2])
+    TodayBlurb(concert: vaultPreview.concerts[2])
   }
 }

--- a/Sources/Site/Music/UI/TodayList.swift
+++ b/Sources/Site/Music/UI/TodayList.swift
@@ -33,11 +33,11 @@ struct TodayList: View {
 
 struct TodayList_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
     NavigationStack {
-      TodayList(concerts: vault.concerts)
-        .musicDestinations(vault)
+      TodayList(concerts: vaultPreview.concerts)
+        .musicDestinations(vaultPreview)
     }
   }
 }

--- a/Sources/Site/Music/UI/VenueBlurb.swift
+++ b/Sources/Site/Music/UI/VenueBlurb.swift
@@ -36,12 +36,12 @@ struct VenueBlurb: View {
 
 struct VenueBlurb_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
-    VenueBlurb(concert: vault.concerts[0])
+    VenueBlurb(concert: vaultPreview.concerts[0])
 
-    VenueBlurb(concert: vault.concerts[1])
+    VenueBlurb(concert: vaultPreview.concerts[1])
 
-    VenueBlurb(concert: vault.concerts[2])
+    VenueBlurb(concert: vaultPreview.concerts[2])
   }
 }

--- a/Sources/Site/Music/UI/VenueDetail.swift
+++ b/Sources/Site/Music/UI/VenueDetail.swift
@@ -90,10 +90,10 @@ struct VenueDetail: View {
 
 struct VenueDetail_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
     NavigationStack {
-      VenueDetail(digest: vault.venueDigests[0])
-        .musicDestinations(vault)
+      VenueDetail(digest: vaultPreview.venueDigests[0])
+        .musicDestinations(vaultPreview)
     }
   }
 }

--- a/Sources/Site/Music/UI/VenueList.swift
+++ b/Sources/Site/Music/UI/VenueList.swift
@@ -113,12 +113,13 @@ struct VenueList: View {
 
 struct VenueList_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
     NavigationStack {
       VenueList(
-        venueDigests: vault.venueDigests, sectioner: vault.sectioner, sort: .constant(.alphabetical)
+        venueDigests: vaultPreview.venueDigests, sectioner: vaultPreview.sectioner,
+        sort: .constant(.alphabetical)
       )
-      .musicDestinations(vault)
+      .musicDestinations(vaultPreview)
     }
   }
 }

--- a/Sources/Site/Music/UI/YearDetail.swift
+++ b/Sources/Site/Music/UI/YearDetail.swift
@@ -47,11 +47,11 @@ struct YearDetail: View {
 
 struct YearDetail_Previews: PreviewProvider {
   static var previews: some View {
-    let vault = Vault.previewData
+    let vaultPreview = Vault.previewData
 
     NavigationStack {
-      YearDetail(digest: vault.digest(for: Annum.year(2001)))
-        .musicDestinations(vault)
+      YearDetail(digest: vaultPreview.digest(for: Annum.year(2001)))
+        .musicDestinations(vaultPreview)
     }
   }
 }

--- a/Tests/SiteTests/ConcertComparatorTests.swift
+++ b/Tests/SiteTests/ConcertComparatorTests.swift
@@ -31,74 +31,74 @@ final class ConcertComparatorTests: XCTestCase {
     let show1 = Show(artists: [artist1.id], date: date, id: "sh0", venue: venue1.id)
     let show2 = Show(artists: [artist2.id], date: dateLater, id: "sh1", venue: venue2.id)
 
-    let vault = createVault(
+    let vaultTest = createVault(
       artists: [artist1, artist2], shows: [show1, show2], venues: [venue1, venue2])
 
-    let concert1 = vault.concertMap[show1.id]!
-    let concert2 = vault.concertMap[show2.id]!
+    let concert1 = vaultTest.concertMap[show1.id]!
+    let concert2 = vaultTest.concertMap[show2.id]!
 
     XCTAssertNotEqual(concert1, concert2)
-    XCTAssertTrue(vault.comparator.compare(lhs: concert1, rhs: concert2))
-    XCTAssertFalse(vault.comparator.compare(lhs: concert2, rhs: concert1))
+    XCTAssertTrue(vaultTest.comparator.compare(lhs: concert1, rhs: concert2))
+    XCTAssertFalse(vaultTest.comparator.compare(lhs: concert2, rhs: concert1))
   }
 
   func testSameDates_differentVenues() throws {
     let show1 = Show(artists: [artist1.id], date: date, id: "sh0", venue: venue1.id)
     let show2 = Show(artists: [artist2.id], date: date, id: "sh1", venue: venue2.id)
 
-    let vault = createVault(
+    let vaultTest = createVault(
       artists: [artist1, artist2], shows: [show1, show2], venues: [venue1, venue2])
 
-    let concert1 = vault.concertMap[show1.id]!
-    let concert2 = vault.concertMap[show2.id]!
+    let concert1 = vaultTest.concertMap[show1.id]!
+    let concert2 = vaultTest.concertMap[show2.id]!
 
     XCTAssertNotEqual(concert1, concert2)
-    XCTAssertFalse(vault.comparator.compare(lhs: concert1, rhs: concert2))
-    XCTAssertTrue(vault.comparator.compare(lhs: concert2, rhs: concert1))
+    XCTAssertFalse(vaultTest.comparator.compare(lhs: concert1, rhs: concert2))
+    XCTAssertTrue(vaultTest.comparator.compare(lhs: concert2, rhs: concert1))
   }
 
   func testSameDates_sameVenues_differentArtists() throws {
     let show1 = Show(artists: [artist1.id], date: date, id: "sh0", venue: venue1.id)
     let show2 = Show(artists: [artist2.id], date: date, id: "sh1", venue: venue1.id)
 
-    let vault = createVault(
+    let vaultTest = createVault(
       artists: [artist1, artist2], shows: [show1, show2], venues: [venue1, venue2])
 
-    let concert1 = vault.concertMap[show1.id]!
-    let concert2 = vault.concertMap[show2.id]!
+    let concert1 = vaultTest.concertMap[show1.id]!
+    let concert2 = vaultTest.concertMap[show2.id]!
 
     XCTAssertNotEqual(concert1, concert2)
-    XCTAssertTrue(vault.comparator.compare(lhs: concert1, rhs: concert2))
-    XCTAssertFalse(vault.comparator.compare(lhs: concert2, rhs: concert1))
+    XCTAssertTrue(vaultTest.comparator.compare(lhs: concert1, rhs: concert2))
+    XCTAssertFalse(vaultTest.comparator.compare(lhs: concert2, rhs: concert1))
   }
 
   func testSameDates_sameVenues_sameArtists() throws {
     let show1 = Show(artists: [artist1.id], date: date, id: "sh0", venue: venue1.id)
     let show2 = Show(artists: [artist1.id], date: date, id: "sh1", venue: venue1.id)
 
-    let vault = createVault(
+    let vaultTest = createVault(
       artists: [artist1, artist2], shows: [show1, show2], venues: [venue1, venue2])
 
-    let concert1 = vault.concertMap[show1.id]!
-    let concert2 = vault.concertMap[show2.id]!
+    let concert1 = vaultTest.concertMap[show1.id]!
+    let concert2 = vaultTest.concertMap[show2.id]!
 
     XCTAssertNotEqual(concert1, concert2)
-    XCTAssertTrue(vault.comparator.compare(lhs: concert1, rhs: concert2))
-    XCTAssertFalse(vault.comparator.compare(lhs: concert2, rhs: concert1))
+    XCTAssertTrue(vaultTest.comparator.compare(lhs: concert1, rhs: concert2))
+    XCTAssertFalse(vaultTest.comparator.compare(lhs: concert2, rhs: concert1))
   }
 
   func testEdgeCase() throws {
     let show1 = Show(artists: [artist1.id], date: date, id: "sh0", venue: venue1.id)
     let show2 = show1
 
-    let vault = createVault(
+    let vaultTest = createVault(
       artists: [artist1, artist2], shows: [show1, show2], venues: [venue1, venue2])
 
-    let concert1 = vault.concertMap[show1.id]!
-    let concert2 = vault.concertMap[show2.id]!
+    let concert1 = vaultTest.concertMap[show1.id]!
+    let concert2 = vaultTest.concertMap[show2.id]!
 
     XCTAssertEqual(concert1, concert2)
-    XCTAssertFalse(vault.comparator.compare(lhs: concert1, rhs: concert2))
-    XCTAssertFalse(vault.comparator.compare(lhs: concert2, rhs: concert1))
+    XCTAssertFalse(vaultTest.comparator.compare(lhs: concert1, rhs: concert2))
+    XCTAssertFalse(vaultTest.comparator.compare(lhs: concert2, rhs: concert1))
   }
 }

--- a/Tests/SiteTests/PathRestorableUserActivityTests.swift
+++ b/Tests/SiteTests/PathRestorableUserActivityTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import Site
 
 final class PathRestorableUserActivityTests: XCTestCase {
-  let vault = Vault.previewData
+  let baseURL = Vault.previewData.baseURL
 
   func testShow() throws {
     let userActivity = NSUserActivity(activityType: "test-type")
@@ -18,7 +18,7 @@ final class PathRestorableUserActivityTests: XCTestCase {
     let concert = Concert(
       show: Show(artists: [], date: PartialDate(), id: "sh17", venue: "v0"),
       venue: Venue(id: "v0", location: Location(city: "c", state: "s"), name: "V0"), artists: [])
-    userActivity.update(concert, url: concert.archivePath.url(using: vault.baseURL))
+    userActivity.update(concert, url: concert.archivePath.url(using: baseURL))
 
     XCTAssertTrue(userActivity.isEligibleForHandoff)
 
@@ -39,7 +39,7 @@ final class PathRestorableUserActivityTests: XCTestCase {
     let userActivity = NSUserActivity(activityType: "test-type")
 
     let artist = Artist(id: "ar0", name: "AR0")
-    userActivity.update(artist, url: artist.archivePath.url(using: vault.baseURL))
+    userActivity.update(artist, url: artist.archivePath.url(using: baseURL))
 
     XCTAssertTrue(userActivity.isEligibleForHandoff)
 
@@ -58,7 +58,7 @@ final class PathRestorableUserActivityTests: XCTestCase {
     let userActivity = NSUserActivity(activityType: "test-type")
 
     let venue = Venue(id: "v10", location: Location(city: "c", state: "s"), name: "V10")
-    userActivity.update(venue, url: venue.archivePath.url(using: vault.baseURL))
+    userActivity.update(venue, url: venue.archivePath.url(using: baseURL))
 
     XCTAssertTrue(userActivity.isEligibleForHandoff)
 
@@ -78,7 +78,7 @@ final class PathRestorableUserActivityTests: XCTestCase {
 
     let item = Annum.year(1990)
 
-    userActivity.update(item, url: item.archivePath.url(using: vault.baseURL))
+    userActivity.update(item, url: item.archivePath.url(using: baseURL))
 
     XCTAssertTrue(userActivity.isEligibleForHandoff)
 
@@ -102,7 +102,7 @@ final class PathRestorableUserActivityTests: XCTestCase {
       show: Show(artists: [], date: PartialDate(), id: "sh17", venue: "v0"),
       venue: Venue(id: "v0", location: Location(city: "c", state: "s"), name: "V0"), artists: [])
 
-    userActivity.update(concert, url: concert.archivePath.url(using: vault.baseURL))
+    userActivity.update(concert, url: concert.archivePath.url(using: baseURL))
 
     XCTAssertTrue(userActivity.isEligibleForPublicIndexing)
     XCTAssertEqual(userActivity.webpageURL, url)


### PR DESCRIPTION
- helps find remaining uses in library code.