### PR TITLE
Add SharePreview to ShareLinks

### DIFF
--- a/Sources/Site/Music/UI/ArchiveCategoryShareModifier.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryShareModifier.swift
@@ -25,7 +25,10 @@ struct ArchiveCategoryShareModifier: ViewModifier {
     content
       .toolbar {
         if let url {
-          ShareLink(item: url, subject: category.subject, message: category.message)
+          ShareLink(
+            item: url, subject: category.subject, message: category.message,
+            preview: SharePreview(
+              category.subject, image: Bundle.main.appIcon))
         }
       }
   }

--- a/Sources/Site/Music/UI/Bundle+AppIcon.swift
+++ b/Sources/Site/Music/UI/Bundle+AppIcon.swift
@@ -1,0 +1,24 @@
+//
+//  File.swift
+//
+//
+//  Created by Greg Bolsinga on 9/11/23.
+//
+
+import SwiftUI
+
+extension Bundle {
+  var appIcon: Image {
+    #if os(iOS)
+      guard let pImage = UIImage(named: "AppIcon") else {
+        return Image(systemName: "questionmark.circle")
+      }
+      return Image(uiImage: pImage)
+    #elseif os(macOS)
+      guard let pImage = NSImage(named: "AppIcon") else {
+        return Image(systemName: "questionmark.circle")
+      }
+      return Image(nsImage: pImage)
+    #endif
+  }
+}

--- a/Sources/Site/Music/UI/PathRestorableShareModifier.swift
+++ b/Sources/Site/Music/UI/PathRestorableShareModifier.swift
@@ -15,7 +15,10 @@ struct PathRestorableShareModifier<T: PathRestorableShareable>: ViewModifier {
     content
       .toolbar {
         if let url {
-          ShareLink(item: url, subject: item.subject, message: item.message)
+          ShareLink(
+            item: url, subject: item.subject, message: item.message,
+            preview: SharePreview(
+              item.subject, image: Bundle.main.appIcon))
         }
       }
   }


### PR DESCRIPTION
- It uses the subject and the AppIcon.
- Fixes #578