### PR TITLE
Fix Notification Non-Sendable warning

### DIFF
--- a/Sources/Site/Music/UI/NotificationModifier.swift
+++ b/Sources/Site/Music/UI/NotificationModifier.swift
@@ -30,7 +30,7 @@ struct NotificationModifier: ViewModifier {
       .task {
         Logger.notification.log("task: \(name.rawValue, privacy: .public)")
         mainDeferredAction()
-        for await _ in NotificationCenter.default.notifications(named: name) {
+        for await _ in NotificationCenter.default.notifications(named: name).map({ $0.name }) {
           Logger.notification.log("notified: \(name.rawValue, privacy: .public)")
           mainDeferredAction()
         }

--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -90,7 +90,9 @@ extension VaultError: LocalizedError {
     defer {
       Logger.vaultModel.log("end day monitoring")
     }
-    for await _ in NotificationCenter.default.notifications(named: .NSCalendarDayChanged) {
+    for await _ in NotificationCenter.default.notifications(named: .NSCalendarDayChanged).map({
+      $0.name
+    }) {
       Logger.vaultModel.log("day changed")
       updateTodayConcerts()
     }


### PR DESCRIPTION
- The issue was the Notification is not sendable. We're not using any data from the Notification, so make it a Sequence of something else.
- Found via https://stackoverflow.com/questions/77070439/swift-silence-non-sendable-notification-cannot-cross-actor-boundary-warning