### PR TITLE
Add AtlasGeocodable

### DIFF
--- a/Sources/Site/Music/Atlas.swift
+++ b/Sources/Site/Music/Atlas.swift
@@ -13,16 +13,18 @@ extension Logger {
   static let atlas = Logger(category: "atlas")
 }
 
-protocol Geocodable: Hashable {
+protocol Geocodable {
   func geocode() async throws -> CLPlacemark
 }
+
+protocol AtlasGeocodable: Geocodable, Codable, Equatable, Hashable {}
 
 private enum Constants {
   static let maxRequests = 50
   static let timeUntilReset = Duration.seconds(60)
 }
 
-actor Atlas<T: Geocodable> {
+actor Atlas<T: AtlasGeocodable> {
   typealias Cache = [T: CLPlacemark]
 
   private var cache: Cache = [:]

--- a/Sources/Site/Music/BatchGeocode.swift
+++ b/Sources/Site/Music/BatchGeocode.swift
@@ -8,7 +8,7 @@
 import CoreLocation
 import Foundation
 
-struct BatchGeocode<T: Geocodable>: AsyncSequence {
+struct BatchGeocode<T: AtlasGeocodable>: AsyncSequence {
   typealias Element = (T, CLPlacemark)
 
   let atlas: Atlas<T>

--- a/Sources/Site/Music/Location+Geocode.swift
+++ b/Sources/Site/Music/Location+Geocode.swift
@@ -22,7 +22,7 @@ extension CNPostalAddress: Geocodable {
   }
 }
 
-extension Location: Geocodable {
+extension Location: AtlasGeocodable {
   public func geocode() async throws -> CLPlacemark {
     try await postalAddress.geocode()
   }

--- a/Sources/Site/Music/UI/MusicDestinationModifier.swift
+++ b/Sources/Site/Music/UI/MusicDestinationModifier.swift
@@ -21,7 +21,7 @@ struct MusicDestinationModifier: ViewModifier {
         case .venue(let iD):
           if let venueDigest = vault.venueDigestMap[iD] {
             VenueDetail(digest: venueDigest, concertCompare: vault.comparator.compare(lhs:rhs:)) {
-              try await vault.atlas.geocode($0)
+              try await vault.atlas.geocode($0.venue)
             }
           }
         case .artist(let iD):

--- a/Sources/Site/Music/Vault.swift
+++ b/Sources/Site/Music/Vault.swift
@@ -22,7 +22,7 @@ extension URL {
 public struct Vault {
   internal let comparator: LibraryComparator
   internal let sectioner: LibrarySectioner
-  internal let atlas: Atlas<VenueDigest>
+  internal let atlas: Atlas<Venue>
   internal let baseURL: URL?
   public let concerts: [Concert]
   public let concertMap: [Concert.ID: Concert]
@@ -40,7 +40,7 @@ public struct Vault {
     let lookup = Lookup(music: music)
     let comparator = LibraryComparator()
     let baseURL = url?.baseURL
-    let atlas = Atlas<VenueDigest>()
+    let atlas = Atlas<Venue>()
 
     let concerts = music.shows.concerts(
       baseURL: baseURL, lookup: lookup, comparator: comparator.compare(lhs:rhs:))
@@ -59,7 +59,7 @@ public struct Vault {
   }
 
   internal init(
-    comparator: LibraryComparator, sectioner: LibrarySectioner, atlas: Atlas<VenueDigest>,
+    comparator: LibraryComparator, sectioner: LibrarySectioner, atlas: Atlas<Venue>,
     baseURL: URL?, concerts: [Concert], artistDigests: [ArtistDigest], venueDigests: [VenueDigest],
     decadesMap: [Decade: [Annum: [Show.ID]]]
   ) {
@@ -82,7 +82,7 @@ public struct Vault {
 
   public static func create(music: Music, url: URL) async -> Vault {
     async let asyncBaseURL = url.baseURL
-    async let asyncAtlas = Atlas<VenueDigest>()
+    async let asyncAtlas = Atlas<Venue>()
     async let asyncLookup = await Lookup.create(music: music)
     async let asyncComparator = await LibraryComparator.create(music: music)
     async let sectioner = await LibrarySectioner.create(music: music)

--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -122,11 +122,11 @@ public final class VaultModel: ObservableObject {
     }
 
     do {
-      for try await (digest, placemark) in BatchGeocode(
-        atlas: vault.atlas, geocodables: vault.venueDigests)
+      for try await (venue, placemark) in BatchGeocode(
+        atlas: vault.atlas, geocodables: vault.venueDigests.map { $0.venue })
       {
-        Logger.vaultModel.log("geocoded: \(digest.id, privacy: .public)")
-        venuePlacemarks[digest.id] = placemark
+        Logger.vaultModel.log("geocoded: \(venue.id, privacy: .public)")
+        venuePlacemarks[venue.id] = placemark
         geocodedVenuesCount = venuePlacemarks.count
       }
     } catch {

--- a/Sources/Site/Music/Venue+Geocodable.swift
+++ b/Sources/Site/Music/Venue+Geocodable.swift
@@ -8,7 +8,7 @@
 import CoreLocation
 import Foundation
 
-extension Venue: Geocodable {
+extension Venue: AtlasGeocodable {
   func geocode() async throws -> CLPlacemark {
     try await location.geocode()
   }

--- a/Sources/Site/Music/VenueDigest.swift
+++ b/Sources/Site/Music/VenueDigest.swift
@@ -30,9 +30,3 @@ extension VenueDigest: LibraryComparable {
     venue.name
   }
 }
-
-extension VenueDigest: Geocodable {
-  func geocode() async throws -> CLPlacemark {
-    try await venue.geocode()
-  }
-}


### PR DESCRIPTION
- Geocodable just means it has a geocode() func.
- AtlasGeocodable means it can be added in the Atlas cache (Codable, Equatable, Hashable).
- Location & Venue are therefore AtlasGeocodable.
- VenueDigest is not AtlasGeocodable, but something must be cached, so geocode its Venue.
- CNPostalAddress remains just Geocodable.