### PR TITLE
Add Nearby Shows

### DIFF
--- a/Sources/Site/Music/UI/ArchiveCategory+FormatStyle.swift
+++ b/Sources/Site/Music/UI/ArchiveCategory+FormatStyle.swift
@@ -32,6 +32,8 @@ extension ArchiveCategory.FormatStyle: Foundation.FormatStyle {
       switch value {
       case .today:
         return "/dates/today.html"
+      case .nearby:
+        return "/stats.html"
       case .stats:
         return "/stats.html"
       case .shows:

--- a/Sources/Site/Music/UI/ArchiveCategory.swift
+++ b/Sources/Site/Music/UI/ArchiveCategory.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 public enum ArchiveCategory: String, CaseIterable {
   case today
+  case nearby
   case stats
   case shows
   case venues
@@ -18,6 +19,8 @@ public enum ArchiveCategory: String, CaseIterable {
     switch self {
     case .today:
       return String(localized: "Today", bundle: .module, comment: "ArchiveCategory Today")
+    case .nearby:
+      return String(localized: "Nearby", bundle: .module, comment: "ArchiveCategory Nearby")
     case .stats:
       return String(localized: "Stats", bundle: .module, comment: "ArchiveCategory Stats")
     case .shows:
@@ -33,6 +36,8 @@ public enum ArchiveCategory: String, CaseIterable {
     switch self {
     case .today:
       Label(self.localizedString, systemImage: "calendar.circle")
+    case .nearby:
+      Label(self.localizedString, systemImage: "location.circle")
     case .stats:
       Label(self.localizedString, systemImage: "chart.bar")
     case .shows:
@@ -50,6 +55,10 @@ public enum ArchiveCategory: String, CaseIterable {
       return String(
         localized: "Display Shows On This Date", bundle: .module,
         comment: "ArchiveCategory.today shared title")
+    case .nearby:
+      return String(
+        localized: "Display Nearby Shows", bundle: .module,
+        comment: "ArchiveCategory.nearby shared title")
     case .stats:
       return String(
         localized: "Show Statistics",

--- a/Sources/Site/Music/UI/ArchiveCategoryDetail.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryDetail.swift
@@ -11,9 +11,11 @@ struct ArchiveCategoryDetail: View {
   let vault: Vault
   let category: ArchiveCategory?
   @Binding var todayConcerts: [Concert]
+  @Binding var nearbyConcerts: [Concert]
   @Binding var venueSort: VenueSort
   @Binding var artistSort: ArtistSort
   @Binding var isCategoryActive: Bool
+  @Binding var geocodingProgress: Double
 
   @ViewBuilder private var stackElement: some View {
     if let category {
@@ -22,6 +24,8 @@ struct ArchiveCategoryDetail: View {
         switch category {
         case .today:
           TodayList(concerts: todayConcerts)
+        case .nearby:
+          NearbyList(concerts: nearbyConcerts, geocodingProgress: $geocodingProgress)
         case .stats:
           List { StatsGrouping(concerts: vault.concerts, displayArchiveCategoryCounts: false) }
             .navigationTitle(Text(category.localizedString))
@@ -53,27 +57,38 @@ struct ArchiveCategoryDetail_Previews: PreviewProvider {
 
     ArchiveCategoryDetail(
       vault: vaultPreview, category: .today, todayConcerts: .constant([]),
-      venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-      isCategoryActive: .constant(true))
+      nearbyConcerts: .constant([]), venueSort: .constant(.alphabetical),
+      artistSort: .constant(.alphabetical), isCategoryActive: .constant(true),
+      geocodingProgress: .constant(0.5))
+
+    ArchiveCategoryDetail(
+      vault: vaultPreview, category: .nearby, todayConcerts: .constant([]),
+      nearbyConcerts: .constant([]), venueSort: .constant(.alphabetical),
+      artistSort: .constant(.alphabetical), isCategoryActive: .constant(true),
+      geocodingProgress: .constant(0.5))
 
     ArchiveCategoryDetail(
       vault: vaultPreview, category: .stats, todayConcerts: .constant([]),
-      venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-      isCategoryActive: .constant(true))
+      nearbyConcerts: .constant([]), venueSort: .constant(.alphabetical),
+      artistSort: .constant(.alphabetical), isCategoryActive: .constant(true),
+      geocodingProgress: .constant(0.5))
 
     ArchiveCategoryDetail(
       vault: vaultPreview, category: .shows, todayConcerts: .constant([]),
-      venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-      isCategoryActive: .constant(true))
+      nearbyConcerts: .constant([]), venueSort: .constant(.alphabetical),
+      artistSort: .constant(.alphabetical), isCategoryActive: .constant(true),
+      geocodingProgress: .constant(0.5))
 
     ArchiveCategoryDetail(
       vault: vaultPreview, category: .venues, todayConcerts: .constant([]),
-      venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-      isCategoryActive: .constant(true))
+      nearbyConcerts: .constant([]), venueSort: .constant(.alphabetical),
+      artistSort: .constant(.alphabetical), isCategoryActive: .constant(true),
+      geocodingProgress: .constant(0.5))
 
     ArchiveCategoryDetail(
       vault: vaultPreview, category: .artists, todayConcerts: .constant([]),
-      venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-      isCategoryActive: .constant(true))
+      nearbyConcerts: .constant([]), venueSort: .constant(.alphabetical),
+      artistSort: .constant(.alphabetical), isCategoryActive: .constant(true),
+      geocodingProgress: .constant(0.5))
   }
 }

--- a/Sources/Site/Music/UI/NearbyBlurb.swift
+++ b/Sources/Site/Music/UI/NearbyBlurb.swift
@@ -1,0 +1,50 @@
+//
+//  NearbyBlurb.swift
+//
+//
+//  Created by Greg Bolsinga on 9/14/23.
+//
+
+import SwiftUI
+
+struct NearbyBlurb: View {
+  let concert: Concert
+
+  @ViewBuilder private var artistsView: some View {
+    VStack(alignment: .leading) {
+      ForEach(concert.artists) { artist in
+        Text(artist.name).font(.headline)
+      }
+    }
+  }
+
+  @ViewBuilder private var detailsView: some View {
+    VStack(alignment: .trailing) {
+      if let venue = concert.venue {
+        Text(venue.name)
+      }
+      Text(concert.show.date.formatted(.compact))
+    }
+    .font(.footnote)
+  }
+
+  var body: some View {
+    HStack {
+      artistsView
+      Spacer()
+      detailsView
+    }
+  }
+}
+
+struct NearbyBlurb_Previews: PreviewProvider {
+  static var previews: some View {
+    let vaultPreview = Vault.previewData
+
+    NearbyBlurb(concert: vaultPreview.concerts[0])
+
+    NearbyBlurb(concert: vaultPreview.concerts[1])
+
+    NearbyBlurb(concert: vaultPreview.concerts[2])
+  }
+}

--- a/Sources/Site/Music/UI/NearbyLabel.swift
+++ b/Sources/Site/Music/UI/NearbyLabel.swift
@@ -1,0 +1,39 @@
+//
+//  NearbyLabel.swift
+//
+//
+//  Created by Greg Bolsinga on 9/16/23.
+//
+
+import SwiftUI
+
+struct NearbyLabel: View {
+  @Binding var nearbyConcertCount: Int
+  @Binding var geocodingProgress: Double
+
+  var body: some View {
+    Label {
+      Text(nearbyConcertCount.formatted(.number))
+        .animation(.easeInOut)
+    } icon: {
+      if geocodingProgress < 1.0 {
+        ProgressView(value: geocodingProgress)
+          .progressViewStyle(.circular)
+          .tint(.accentColor)
+          #if os(macOS)
+            .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 10))
+          #endif
+      }
+    }
+  }
+}
+
+struct NearbyLabel_Previews: PreviewProvider {
+  static var previews: some View {
+    NearbyLabel(nearbyConcertCount: .constant(10), geocodingProgress: .constant(0.0))
+
+    NearbyLabel(nearbyConcertCount: .constant(10), geocodingProgress: .constant(0.5))
+
+    NearbyLabel(nearbyConcertCount: .constant(10), geocodingProgress: .constant(1.0))
+  }
+}

--- a/Sources/Site/Music/UI/NearbyList.swift
+++ b/Sources/Site/Music/UI/NearbyList.swift
@@ -1,0 +1,53 @@
+//
+//  NearbyList.swift
+//
+//
+//  Created by Greg Bolsinga on 9/14/23.
+//
+
+import SwiftUI
+
+struct NearbyList: View {
+  let concerts: [Concert]
+  @Binding var geocodingProgress: Double
+
+  var body: some View {
+    VStack {
+      ZStack {
+        if concerts.isEmpty {
+          Text(
+            "No Shows Nearby", bundle: .module,
+            comment: "Text shown when there are no nearby concerts."
+          )
+          .font(.title)
+          .foregroundColor(.secondary)
+        } else {
+          List(concerts) { concert in
+            NavigationLink(value: concert) { NearbyBlurb(concert: concert) }
+          }
+          .listStyle(.plain)
+        }
+      }
+      if geocodingProgress < 1.0 {
+        ProgressView(value: geocodingProgress)
+          .progressViewStyle(.circular)
+          .tint(.accentColor)
+          #if os(macOS)
+            .padding(EdgeInsets(top: 0, leading: 0, bottom: 10, trailing: 0))
+          #endif
+      }
+    }
+    .navigationTitle(Text("Nearby Shows", bundle: .module, comment: "Nearby Shows Title"))
+  }
+}
+
+struct NearbyList_Previews: PreviewProvider {
+  static var previews: some View {
+    let vaultPreview = Vault.previewData
+
+    NavigationStack {
+      NearbyList(concerts: vaultPreview.concerts, geocodingProgress: .constant(0.5))
+        .musicDestinations(vaultPreview)
+    }
+  }
+}

--- a/Sources/Site/Music/Vault.swift
+++ b/Sources/Site/Music/Vault.swift
@@ -120,7 +120,7 @@ public struct Vault {
     guard let baseURL else {
       return nil
     }
-    guard category != .today, category != .stats else {
+    guard category != .today, category != .nearby, category != .stats else {
       return nil
     }
     var urlComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)

--- a/Sources/Site/Resources/en.lproj/Localizable.strings
+++ b/Sources/Site/Resources/en.lproj/Localizable.strings
@@ -41,9 +41,9 @@ ArchiveCategory Artists */
 /* Title of the comment section of ShowDetail */
 "Comment" = "Comment";
 
-/* Label in the chart for the Count in MonthChart.
-Label in the chart for the Count in WeekdayChart.
-Label in the chart for the Count in StateChart. */
+/* Label in the chart for the Count in WeekdayChart.
+Label in the chart for the Count in StateChart.
+Label in the chart for the Count in MonthChart. */
 "Count" = "Count";
 
 /* Title of the date section of ShowDetail */
@@ -54,6 +54,9 @@ Label in the chart for the Count in StateChart. */
 
 /* String for when a Decade is unknown. */
 "Decade Unknown" = "Decade Unknown";
+
+/* ArchiveCategory.nearby shared title */
+"Display Nearby Shows" = "Display Nearby Shows";
 
 /* ArchiveCategory.today shared title */
 "Display Shows On This Date" = "Display Shows On This Date";
@@ -68,11 +71,26 @@ Venue First Set Caption */
 /* Title of the Location / Address Section for VenueDetail. */
 "Location" = "Location";
 
+/* Text shown when location services are restrictued by user. */
+"Location Disabled" = "Location Disabled";
+
+/* Text shown when location services are denied. */
+"Location Unavailable" = "Location Unavailable";
+
 /* Label in the chart for the Month in MonthChart. */
 "Month" = "Month";
 
 /* Months Stats */
 "Months" = "Months";
+
+/* ArchiveCategory Nearby */
+"Nearby" = "Nearby";
+
+/* Nearby Shows Title */
+"Nearby Shows" = "Nearby Shows";
+
+/* Text shown when there are no nearby concerts. */
+"No Shows Nearby" = "No Shows Nearby";
 
 /* Text shown when there are no shows today. */
 "No Shows On This Day" = "No Shows On This Day";
@@ -129,9 +147,9 @@ Venue First Set Caption */
 "Show Years" = "Show Years";
 
 /* Title of the Shows section of ArtistDetail
+ArchiveCategory Shows
 Title of the Shows section of YearDetail
-Title of the Shows section of VenueDetail
-ArchiveCategory Shows */
+Title of the Shows section of VenueDetail */
 "Shows" = "Shows";
 
 /* Venue shared string */
@@ -189,8 +207,8 @@ ArtistSort.showYearRange */
 /* VenueList searchPrompt */
 "Venue Names" = "Venue Names";
 
-/* ArchiveCategory Venues
-Title for the Venue Detail */
+/* Title for the Venue Detail
+ArchiveCategory Venues */
 "Venues" = "Venues";
 
 /* Label in the chart for the Weekday in WeekdayChart. */


### PR DESCRIPTION
- It will show the nearby shows if location access is granted.
- It will show a spinner if the venues are still all being geocoded.
- Fixes #237