### PR TITLE
Add @MainActor to fix StrictConcurrency issue.

### DIFF
--- a/Sources/Site/Music/UI/ArchiveCategoryDetail.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryDetail.swift
@@ -17,6 +17,7 @@ struct ArchiveCategoryDetail: View {
   @Binding var isCategoryActive: Bool
   @Binding var geocodingProgress: Double
 
+  @MainActor
   @ViewBuilder private var stackElement: some View {
     if let category {
       let url = vault.createURL(forCategory: category)


### PR DESCRIPTION
Fixes:

```
/Users/bolsinga/Documents/code/git/site/Sources/Site/Music/UI/ArchiveCategoryDetail.swift:31:11: error: call to main actor-isolated initializer 'init(content:)' in a synchronous nonisolated context
          List { StatsGrouping(concerts: vault.concerts, displayArchiveCategoryCounts: false) }
          ^
SwiftUI.List:3:23: note: calls to initializer 'init(content:)' from outside of its actor context are implicitly asynchronous
    @MainActor public init(@ViewBuilder content: () -> Content)
                      ^
```