### PR TITLE
Declare AtlasGeocodable as Sendable

### DIFF
--- a/Sources/Site/Music/Atlas.swift
+++ b/Sources/Site/Music/Atlas.swift
@@ -17,7 +17,7 @@ protocol Geocodable {
   func geocode() async throws -> CLPlacemark
 }
 
-protocol AtlasGeocodable: Geocodable, Codable, Equatable, Hashable {}
+protocol AtlasGeocodable: Geocodable, Codable, Equatable, Hashable, Sendable {}
 
 private enum Constants {
   static let maxRequests = 50


### PR DESCRIPTION
Fixes:
```
/Users/bolsinga/Documents/code/git/site/Sources/Site/Music/BatchGeocode.swift:29:47: warning: passing argument of non-sendable type 'T' into actor-isolated context may introduce data races
      let placemark = try await atlas.geocode(geocodable)
                                              ^
/Users/bolsinga/Documents/code/git/site/Sources/Site/Music/BatchGeocode.swift:11:21: note: consider making generic parameter 'T' conform to the 'Sendable' protocol
struct BatchGeocode<T: AtlasGeocodable>: AsyncSequence {
                    ^
```
- Found by StrictConcurrency