### PR TITLE
Declare Concert Sendable

### DIFF
--- a/Sources/Site/Music/Concert.swift
+++ b/Sources/Site/Music/Concert.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Concert: Equatable, Hashable, Identifiable {
+public struct Concert: Equatable, Hashable, Identifiable, Sendable {
   public var id: Show.ID { show.id }
 
   public let show: Show


### PR DESCRIPTION
Fixes:
```
/Users/bolsinga/Documents/code/git/site/Sources/Site/Music/Vault.swift:102:17: warning: capture of 'concerts' with non-sendable type '[Concert]' in 'async let' binding
      concerts: concerts, baseURL: baseURL, lookup: lookup, comparator: comparator.compare(lhs:rhs:)
                ^
/Users/bolsinga/Documents/code/git/site/Sources/Site/Music/Concert.swift:10:15: note: consider making struct 'Concert' conform to the 'Sendable' protocol
public struct Concert: Equatable, Hashable, Identifiable {
              ^
                                                        , Sendable
```
- Found by StrictConcurrency