### PR TITLE
Use @preconcurrency CoreLocation

### DIFF
--- a/Sources/Site/Music/UI/MusicDestinationModifier.swift
+++ b/Sources/Site/Music/UI/MusicDestinationModifier.swift
@@ -5,6 +5,7 @@
 //  Created by Greg Bolsinga on 4/6/23.
 //
 
+@preconcurrency import CoreLocation
 import SwiftUI
 
 struct MusicDestinationModifier: ViewModifier {


### PR DESCRIPTION
- This was hard to "fix" because it compiled w/o the `import CoreLocation`. Adding that then emitted the fix-it when building.
- Found by StrictConcurrency
- Related to #653

Fixes:
```
/Users/bolsinga/Documents/code/git/site/Sources/Site/Music/UI/MusicDestinationModifier.swift:25:37: warning: non-sendable type 'CLPlacemark' returned by implicitly asynchronous call to actor-isolated function cannot cross actor boundary
              try await vault.atlas.geocode($0.venue)
                                    ^
CoreLocation.CLPlacemark:2:12: note: class 'CLPlacemark' does not conform to the 'Sendable' protocol
open class CLPlacemark : NSObject, NSCopying, NSSecureCoding {
           ^
/Users/bolsinga/Documents/code/git/site/Sources/Site/Music/UI/MusicDestinationModifier.swift:8:2: remark: add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'CoreLocation'
 import CoreLocation
 ^
 @preconcurrency
```