### PR TITLE
Fix when different Scenes have different nearbyDistanceThresholds.

### DIFF
--- a/Sources/Site/Music/UI/ArchiveCategoryDetail.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryDetail.swift
@@ -5,6 +5,7 @@
 //  Created by Greg Bolsinga on 6/7/23.
 //
 
+import CoreLocation
 import SwiftUI
 
 struct ArchiveCategoryDetail: View {
@@ -15,6 +16,7 @@ struct ArchiveCategoryDetail: View {
   @Binding var artistSort: ArtistSort
   let isCategoryActive: Bool
   @Binding var locationFilter: LocationFilter
+  let nearbyDistanceThreshold: CLLocationDistance
 
   @MainActor
   @ViewBuilder private var stackElement: some View {
@@ -29,13 +31,15 @@ struct ArchiveCategoryDetail: View {
             .navigationTitle(Text(category.localizedString))
         case .shows:
           ShowYearList(
-            decadesMap: vault.decadesMap, nearbyConcertIDs: Set(model.nearbyConcerts.map { $0.id }),
+            decadesMap: vault.decadesMap,
+            nearbyConcertIDs: Set(model.concertsNearby(nearbyDistanceThreshold).map { $0.id }),
             locationFilter: $locationFilter, geocodingProgress: model.geocodingProgress,
             locationAuthorization: model.locationAuthorization)
         case .venues:
           VenueList(
             venueDigests: vault.venueDigests,
-            nearbyVenueIDs: Set(model.nearbyConcerts.compactMap { $0.venue?.id }),
+            nearbyVenueIDs: Set(
+              model.concertsNearby(nearbyDistanceThreshold).compactMap { $0.venue?.id }),
             sectioner: vault.sectioner, sort: $venueSort,
             locationFilter: $locationFilter, geocodingProgress: model.geocodingProgress,
             locationAuthorization: model.locationAuthorization)
@@ -61,33 +65,33 @@ struct ArchiveCategoryDetail: View {
   ArchiveCategoryDetail(
     vault: vaultPreviewData, model: vaultModelPreviewData, category: .today,
     venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-    isCategoryActive: true, locationFilter: .constant(.none))
+    isCategoryActive: true, locationFilter: .constant(.none), nearbyDistanceThreshold: 1.0)
 }
 
 #Preview {
   ArchiveCategoryDetail(
     vault: vaultPreviewData, model: vaultModelPreviewData, category: .stats,
     venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-    isCategoryActive: true, locationFilter: .constant(.none))
+    isCategoryActive: true, locationFilter: .constant(.none), nearbyDistanceThreshold: 1.0)
 }
 
 #Preview {
   ArchiveCategoryDetail(
     vault: vaultPreviewData, model: vaultModelPreviewData, category: .shows,
     venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-    isCategoryActive: true, locationFilter: .constant(.none))
+    isCategoryActive: true, locationFilter: .constant(.none), nearbyDistanceThreshold: 1.0)
 }
 
 #Preview {
   ArchiveCategoryDetail(
     vault: vaultPreviewData, model: vaultModelPreviewData, category: .venues,
     venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-    isCategoryActive: true, locationFilter: .constant(.none))
+    isCategoryActive: true, locationFilter: .constant(.none), nearbyDistanceThreshold: 1.0)
 }
 
 #Preview {
   ArchiveCategoryDetail(
     vault: vaultPreviewData, model: vaultModelPreviewData, category: .artists,
     venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-    isCategoryActive: true, locationFilter: .constant(.none))
+    isCategoryActive: true, locationFilter: .constant(.none), nearbyDistanceThreshold: 1.0)
 }

--- a/Sources/Site/Music/UI/ArchiveCategorySplit.swift
+++ b/Sources/Site/Music/UI/ArchiveCategorySplit.swift
@@ -62,7 +62,7 @@ struct ArchiveCategorySplit: View {
           vault: vault, model: model, category: archiveNavigation.selectedCategory,
           venueSort: $venueSort, artistSort: $artistSort,
           isCategoryActive: archiveNavigation.navigationPath.isEmpty,
-          locationFilter: $locationFilter)
+          locationFilter: $locationFilter, nearbyDistanceThreshold: nearbyDistanceThreshold)
       }
     }
     .archiveStorage(archiveNavigation: archiveNavigation)
@@ -95,12 +95,6 @@ struct ArchiveCategorySplit: View {
           Logger.link.error("ArchiveCategory to URL error: \(error, privacy: .public)")
         }
       }
-    }
-    .onAppear {
-      model.nearbyDistanceThreshold = self.nearbyDistanceThreshold
-    }
-    .onChange(of: nearbyDistanceThreshold) { _, newValue in
-      model.nearbyDistanceThreshold = newValue
     }
   }
 }

--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -42,7 +42,6 @@ enum LocationAuthorization {
   var geocodedVenuesCount = 0
   var currentLocation: CLLocation?
   var locationAuthorization = LocationAuthorization.allowed
-  var nearbyDistanceThreshold: CLLocationDistance = 16093.44  // 10 miles
 
   private let locationManager = LocationManager(
     activityType: .other,
@@ -173,9 +172,9 @@ enum LocationAuthorization {
     }
   }
 
-  var nearbyConcerts: [Concert] {
+  func concertsNearby(_ distanceThreshold: CLLocationDistance) -> [Concert] {
     guard let currentLocation else { return [] }
-    return concerts(nearby: currentLocation, distanceThreshold: nearbyDistanceThreshold)
+    return concerts(nearby: currentLocation, distanceThreshold: distanceThreshold)
   }
 
   private func concerts(nearby location: CLLocation, distanceThreshold: CLLocationDistance)


### PR DESCRIPTION
Basically, @SceneStorage is not global, but the VaultModel is global.

Revert "nearbyConcerts is now a computed property of VaultModel (#698)"

This reverts commit 6efec077806931254ddfdb76e245bc4f6fea22ed.