### PR TITLE
NearbyModel now has a VaultModel

### DIFF
--- a/Sources/Site/Music/NearbyModel.swift
+++ b/Sources/Site/Music/NearbyModel.swift
@@ -11,16 +11,17 @@ import Foundation
 @Observable final class NearbyModel {
   var distanceThreshold: CLLocationDistance
   var locationFilter: LocationFilter
-  var locationAuthorization: LocationAuthorization
-  var geocodingProgress: Double
+  var model: VaultModel
 
   internal init(
     distanceThreshold: CLLocationDistance = 0, locationFilter: LocationFilter = .none,
-    locationAuthorization: LocationAuthorization = .allowed, geocodingProgress: Double = 0
+    vaultModel: VaultModel
   ) {
     self.distanceThreshold = distanceThreshold
     self.locationFilter = locationFilter
-    self.locationAuthorization = locationAuthorization
-    self.geocodingProgress = geocodingProgress
+    self.model = vaultModel
   }
+
+  var locationAuthorization: LocationAuthorization { model.locationAuthorization }
+  var geocodingProgress: Double { model.geocodingProgress }
 }

--- a/Sources/Site/Music/UI/ArchiveCategoryDetail.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryDetail.swift
@@ -59,36 +59,41 @@ struct ArchiveCategoryDetail: View {
 }
 
 #Preview {
-  ArchiveCategoryDetail(
-    model: VaultModel(vaultPreviewData, executeAsynchronousTasks: false), category: .today,
-    venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-    isCategoryActive: true, nearbyModel: NearbyModel())
+  let vaultModel = VaultModel(vaultPreviewData, executeAsynchronousTasks: false)
+  return ArchiveCategoryDetail(
+    model: vaultModel, category: .today, venueSort: .constant(.alphabetical),
+    artistSort: .constant(.alphabetical), isCategoryActive: true,
+    nearbyModel: NearbyModel(vaultModel: vaultModel))
 }
 
 #Preview {
-  ArchiveCategoryDetail(
-    model: VaultModel(vaultPreviewData, executeAsynchronousTasks: false), category: .stats,
-    venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-    isCategoryActive: true, nearbyModel: NearbyModel())
+  let vaultModel = VaultModel(vaultPreviewData, executeAsynchronousTasks: false)
+  return ArchiveCategoryDetail(
+    model: vaultModel, category: .stats, venueSort: .constant(.alphabetical),
+    artistSort: .constant(.alphabetical), isCategoryActive: true,
+    nearbyModel: NearbyModel(vaultModel: vaultModel))
 }
 
 #Preview {
-  ArchiveCategoryDetail(
-    model: VaultModel(vaultPreviewData, executeAsynchronousTasks: false), category: .shows,
-    venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-    isCategoryActive: true, nearbyModel: NearbyModel())
+  let vaultModel = VaultModel(vaultPreviewData, executeAsynchronousTasks: false)
+  return ArchiveCategoryDetail(
+    model: vaultModel, category: .shows, venueSort: .constant(.alphabetical),
+    artistSort: .constant(.alphabetical), isCategoryActive: true,
+    nearbyModel: NearbyModel(vaultModel: vaultModel))
 }
 
 #Preview {
-  ArchiveCategoryDetail(
-    model: VaultModel(vaultPreviewData, executeAsynchronousTasks: false), category: .venues,
-    venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-    isCategoryActive: true, nearbyModel: NearbyModel())
+  let vaultModel = VaultModel(vaultPreviewData, executeAsynchronousTasks: false)
+  return ArchiveCategoryDetail(
+    model: vaultModel, category: .venues, venueSort: .constant(.alphabetical),
+    artistSort: .constant(.alphabetical), isCategoryActive: true,
+    nearbyModel: NearbyModel(vaultModel: vaultModel))
 }
 
 #Preview {
-  ArchiveCategoryDetail(
-    model: VaultModel(vaultPreviewData, executeAsynchronousTasks: false), category: .artists,
-    venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
-    isCategoryActive: true, nearbyModel: NearbyModel())
+  let vaultModel = VaultModel(vaultPreviewData, executeAsynchronousTasks: false)
+  return ArchiveCategoryDetail(
+    model: vaultModel, category: .artists, venueSort: .constant(.alphabetical),
+    artistSort: .constant(.alphabetical), isCategoryActive: true,
+    nearbyModel: NearbyModel(vaultModel: vaultModel))
 }

--- a/Sources/Site/Music/UI/ArchiveCategorySplit.swift
+++ b/Sources/Site/Music/UI/ArchiveCategorySplit.swift
@@ -20,7 +20,12 @@ struct ArchiveCategorySplit: View {
   @SceneStorage("artist.sort") private var artistSort = ArtistSort.alphabetical
 
   @State private var archiveNavigation = ArchiveNavigation()
-  @State private var nearbyModel = NearbyModel()
+  @State private var nearbyModel: NearbyModel
+
+  internal init(model: VaultModel) {
+    self.model = model
+    self.nearbyModel = NearbyModel(vaultModel: model)
+  }
 
   private var vault: Vault { model.vault }
 
@@ -94,12 +99,6 @@ struct ArchiveCategorySplit: View {
           Logger.link.error("ArchiveCategory to URL error: \(error, privacy: .public)")
         }
       }
-    }
-    .onChange(of: model.locationAuthorization) { _, newValue in
-      nearbyModel.locationAuthorization = newValue
-    }
-    .onChange(of: model.geocodingProgress) { _, newValue in
-      nearbyModel.geocodingProgress = newValue
     }
   }
 }

--- a/Sources/Site/Music/UI/LocationFilterModifier.swift
+++ b/Sources/Site/Music/UI/LocationFilterModifier.swift
@@ -90,14 +90,22 @@ extension View {
 #Preview {
   Text("Enabled-Geocoding-Allowed")
     .locationFilter(
-      NearbyModel(locationFilter: .nearby, locationAuthorization: .allowed, geocodingProgress: 0),
+      NearbyModel(
+        locationFilter: .nearby,
+        vaultModel: VaultModel(
+          vaultPreviewData, executeAsynchronousTasks: false, fakeLocationAuthorization: .allowed,
+          fakeGeocodingProgress: 0)),
       filteredDataIsEmpty: true, loadLocationFilterFromStorage: false)
 }
 
 #Preview {
   Text("Enabled-Geocoding-Allowed-Empty")
     .locationFilter(
-      NearbyModel(locationFilter: .nearby, locationAuthorization: .allowed, geocodingProgress: 1),
+      NearbyModel(
+        locationFilter: .nearby,
+        vaultModel: VaultModel(
+          vaultPreviewData, executeAsynchronousTasks: false, fakeLocationAuthorization: .allowed,
+          fakeGeocodingProgress: 1)),
       filteredDataIsEmpty: true, loadLocationFilterFromStorage: false)
 }
 
@@ -105,13 +113,20 @@ extension View {
   Text(String("Enabled-Geocoding-Restricted"))
     .locationFilter(
       NearbyModel(
-        locationFilter: .nearby, locationAuthorization: .restricted, geocodingProgress: 0),
+        locationFilter: .nearby,
+        vaultModel: VaultModel(
+          vaultPreviewData, executeAsynchronousTasks: false, fakeLocationAuthorization: .restricted,
+          fakeGeocodingProgress: 0)),
       filteredDataIsEmpty: false, loadLocationFilterFromStorage: false)
 }
 
 #Preview {
   Text("Enabled-Geocoding-Denied")
     .locationFilter(
-      NearbyModel(locationFilter: .nearby, locationAuthorization: .denied, geocodingProgress: 1),
+      NearbyModel(
+        locationFilter: .nearby,
+        vaultModel: VaultModel(
+          vaultPreviewData, executeAsynchronousTasks: false, fakeLocationAuthorization: .denied,
+          fakeGeocodingProgress: 1)),
       filteredDataIsEmpty: false, loadLocationFilterFromStorage: false)
 }


### PR DESCRIPTION
- This is necessary because onChange: does not always update geocoding to 1.0, despite it being 1.0
- Instead of trying to pass the properties from VaultModel to NearbyModel and assuming that works (is this a bug???), have NearbyModel have a VaultModel to just get the property values directly.
- Looking for a way to have two Observable models where they can be independent instead of dependent. Not now, however.
- This was a bug in #726 that was not observed right away. :(