### PR TITLE
decode category activity logger is a local variable

### DIFF
--- a/Sources/Site/Music/NSUserActivity+ArchiveCategory.swift
+++ b/Sources/Site/Music/NSUserActivity+ArchiveCategory.swift
@@ -11,7 +11,6 @@ import os
 
 extension Logger {
   public static let updateCategoryActivity = Logger(category: "updateCategoryActivity")
-  public static let decodeCategoryActivity = Logger(category: "decodeCategoryActivity")
 }
 
 extension NSUserActivity {
@@ -57,25 +56,25 @@ extension NSUserActivity {
     self.expirationDate = .now + (60 * 60 * 24)
   }
 
-  func archiveCategory() throws -> ArchiveCategory {
-    Logger.decodeCategoryActivity.log("type: \(self.activityType, privacy: .public)")
+  func archiveCategory(_ logger: Logger) throws -> ArchiveCategory {
+    logger.log("type: \(self.activityType, privacy: .public)")
 
     guard let userInfo = self.userInfo else {
-      Logger.decodeCategoryActivity.error("no userInfo")
+      logger.error("no userInfo")
       throw DecodeError.noUserInfo
     }
 
     guard let value = userInfo[NSUserActivity.archiveCategoryKey] else {
-      Logger.decodeCategoryActivity.error("no archiveCategoryKey")
+      logger.error("no archiveCategoryKey")
       throw DecodeError.noArchiveKey
     }
 
     guard let archiveCategoryString = value as? String else {
-      Logger.decodeCategoryActivity.error("archiveCategoryKey not String")
+      logger.error("archiveCategoryKey not String")
       throw DecodeError.archiveKeyIncorrectType
     }
 
-    Logger.decodeCategoryActivity.log("decode: \(archiveCategoryString, privacy: .public)")
+    logger.log("decode: \(archiveCategoryString, privacy: .public)")
 
     guard let category = ArchiveCategory(rawValue: archiveCategoryString) else {
       throw DecodeError.invalidArchiveCategoryString

--- a/Sources/Site/Music/UI/ArchiveCategorySplit.swift
+++ b/Sources/Site/Music/UI/ArchiveCategorySplit.swift
@@ -11,14 +11,13 @@ import os
 
 struct ArchiveCategorySplit: View {
   var model: VaultModel
+  private let decodeCategoryActivityLogger = Logger(category: "decodeCategoryActivity")
 
   @SceneStorage("venue.sort") private var venueSort = VenueSort.alphabetical
   @SceneStorage("artist.sort") private var artistSort = ArtistSort.alphabetical
 
   @State private var archiveNavigation = ArchiveNavigation()
   @State private var nearbyModel: NearbyModel
-
-  private let decodeCategoryActivityLogger = Logger(category: "decodeCategoryActivity")
 
   internal init(model: VaultModel) {
     self.model = model

--- a/Sources/Site/Music/UI/ArchiveCategorySplit.swift
+++ b/Sources/Site/Music/UI/ArchiveCategorySplit.swift
@@ -18,14 +18,14 @@ struct ArchiveCategorySplit: View {
   @State private var archiveNavigation = ArchiveNavigation()
   @State private var nearbyModel: NearbyModel
 
+  private let decodeCategoryActivityLogger = Logger(category: "decodeCategoryActivity")
+
   internal init(model: VaultModel) {
     self.model = model
     self.nearbyModel = NearbyModel(vaultModel: model)
   }
 
   private var vault: Vault { model.vault }
-
-  private let decodeCategoryActivityLogger = Logger(category: "decodeCategoryActivity")
 
   @MainActor
   @ViewBuilder var sidebar: some View {

--- a/Sources/Site/Music/UI/ArchiveCategorySplit.swift
+++ b/Sources/Site/Music/UI/ArchiveCategorySplit.swift
@@ -11,7 +11,6 @@ import os
 
 struct ArchiveCategorySplit: View {
   var model: VaultModel
-  private let decodeCategoryActivityLogger = Logger(category: "decodeCategoryActivity")
 
   @SceneStorage("venue.sort") private var venueSort = VenueSort.alphabetical
   @SceneStorage("artist.sort") private var artistSort = ArtistSort.alphabetical
@@ -75,6 +74,7 @@ struct ArchiveCategorySplit: View {
       }
     }
     .onContinueUserActivity(ArchiveCategory.activityType) { userActivity in
+      let decodeCategoryActivityLogger = Logger(category: "decodeCategoryActivity")
       do {
         archiveNavigation.navigate(
           to: try userActivity.archiveCategory(decodeCategoryActivityLogger))

--- a/Sources/Site/Music/UI/ArchiveCategorySplit.swift
+++ b/Sources/Site/Music/UI/ArchiveCategorySplit.swift
@@ -25,6 +25,8 @@ struct ArchiveCategorySplit: View {
 
   private var vault: Vault { model.vault }
 
+  private let decodeCategoryActivityLogger = Logger(category: "decodeCategoryActivity")
+
   @MainActor
   @ViewBuilder var sidebar: some View {
     List(ArchiveCategory.allCases, id: \.self, selection: $archiveNavigation.selectedCategory) {
@@ -75,9 +77,10 @@ struct ArchiveCategorySplit: View {
     }
     .onContinueUserActivity(ArchiveCategory.activityType) { userActivity in
       do {
-        archiveNavigation.navigate(to: try userActivity.archiveCategory())
+        archiveNavigation.navigate(
+          to: try userActivity.archiveCategory(decodeCategoryActivityLogger))
       } catch {
-        Logger.decodeActivity.error("error: \(error, privacy: .public)")
+        decodeCategoryActivityLogger.error("error: \(error, privacy: .public)")
       }
     }
     .onOpenURL { url in


### PR DESCRIPTION
- pass it into category methods.
- Unable to keep it as an instance property when building on 5.9 on GitHub. Things worked fine locally with swift 5.10