### PR TITLE
RefreshCommand is not agnostic of the model

### DIFF
--- a/Sources/Site/Music/UI/RefreshCommand.swift
+++ b/Sources/Site/Music/UI/RefreshCommand.swift
@@ -8,19 +8,17 @@
 import SwiftUI
 
 #if !os(tvOS)
-  public struct RefreshCommand: Commands {
-    public var model: SiteModel
+  public struct RefreshCommand: Commands, Sendable {
+    let refreshAction: (@Sendable () async -> Void)
 
-    public init(model: SiteModel) {
-      self.model = model
+    public init(refreshAction: (@escaping @Sendable () async -> Void)) {
+      self.refreshAction = refreshAction
     }
 
     public var body: some Commands {
       CommandGroup(after: .newItem) {
         Button {
-          Task {
-            await model.load()
-          }
+          Task { await refreshAction() }
         } label: {
           Text("Refresh", bundle: .module)
         }


### PR DESCRIPTION
- Moves the concurrency warning up to the app, so this is just kicking the can...