### PR TITLE
Revert "backup to .4 releases since github does not have .5 (#820)"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,9 @@ let package = Package(
   name: "site",
   defaultLocalization: "en",
   platforms: [
-    .macOS("14.4"),
-    .iOS("17.4"),
-    .tvOS("17.4"),
+    .macOS("14.5"),
+    .iOS("17.5"),
+    .tvOS("17.5"),
   ],
   products: [
     .library(name: "Site", targets: ["Site"]),


### PR DESCRIPTION
This reverts commit 1ef924934f610c420773c76118b9b8ed4457a8bc.

This will work now that github actions are using Xcode 15.4