### PR TITLE
Just annotate logging concurrency issues for Swift 6.0

### DIFF
--- a/Sources/Site/Music/AtlasCache.swift
+++ b/Sources/Site/Music/AtlasCache.swift
@@ -9,6 +9,13 @@ import CoreLocation
 import Foundation
 import os
 
+extension Logger {
+  nonisolated(unsafe) static let atlasCache = Logger(category: "atlasCache")
+  #if swift(>=6.0)
+    #warning("nonisolated(unsafe) unneeded.")
+  #endif
+}
+
 private let expirationOffset = 60.0 * 60.0 * 24.0 * 30.0 * 6.0  // Six months
 private let ExpirationStaggerDuration = 60.0 * 60.0 * 6.0  // Quarter day
 
@@ -24,8 +31,6 @@ actor AtlasCache<T: AtlasGeocodable> {
   private var staggerOffset = 0.0
   private var cache: [T: Value] = [:]
 
-  private let atlasCache = Logger(category: "atlasCache")
-
   internal init(fileName: String = "atlas.json") {
     self.fileName = fileName
 
@@ -35,11 +40,11 @@ actor AtlasCache<T: AtlasGeocodable> {
       self.cache = diskCache.filter { $0.value.expirationDate >= now }  // Include those whose expiration date has not passed .now
 
       if self.cache.count != diskCache.count {
-        atlasCache.log("removing expired items")
+        Logger.atlasCache.log("removing expired items")
         try self.cache.save(fileName: fileName)  // Some expired, so re-write the file.
       }
     } catch {
-      atlasCache.error("Cache Read Error: \(error, privacy: .public)")
+      Logger.atlasCache.error("Cache Read Error: \(error, privacy: .public)")
       self.cache = [:]
     }
   }
@@ -66,7 +71,7 @@ actor AtlasCache<T: AtlasGeocodable> {
       do {
         try cache.save(fileName: fileName)
       } catch {
-        atlasCache.error("Cache Save Error: \(error, privacy: .public)")
+        Logger.atlasCache.error("Cache Save Error: \(error, privacy: .public)")
       }
     }
   }

--- a/Sources/Site/Music/Lookup.swift
+++ b/Sources/Site/Music/Lookup.swift
@@ -6,7 +6,14 @@
 //
 
 import Foundation
-@preconcurrency import os
+import os
+
+extension Logger {
+  nonisolated(unsafe) static let lookup = Logger(category: "lookup")
+#if swift(>=6.0)
+  #warning("nonisolated(unsafe) unneeded.")
+#endif
+}
 
 private func createLookup<T: Identifiable>(_ sequence: [T]) -> [T.ID: T] {
   sequence.reduce(into: [:]) { $0[$1.id] = $1 }
@@ -25,8 +32,6 @@ public struct Lookup: Sendable {
   private let artistFirstSetsMap: [Artist.ID: FirstSet]
   private let venueFirstSetsMap: [Venue.ID: FirstSet]
   private let relationMap: [String: [String]]  // Artist/Venue ID : [Artist/Venue ID]
-
-  private let lookup = Logger(category: "lookup")
 
   public init(music: Music) {
     // non-parallel, used for Previews, tests
@@ -126,7 +131,7 @@ public struct Lookup: Sendable {
 
   public func venueForShow(_ show: Show) -> Venue? {
     guard let venue = venueMap[show.venue] else {
-      lookup.log("Show: \(show.id, privacy: .public) missing venue")
+      Logger.lookup.log("Show: \(show.id, privacy: .public) missing venue")
       return nil
     }
     return venue
@@ -136,7 +141,8 @@ public struct Lookup: Sendable {
     var showArtists = [Artist]()
     for id in show.artists {
       guard let artist = artistMap[id] else {
-        lookup.log("Show: \(show.id, privacy: .public) missing artist: \(id, privacy: .public)")
+        Logger.lookup.log(
+          "Show: \(show.id, privacy: .public) missing artist: \(id, privacy: .public)")
         continue
       }
       showArtists.append(artist)

--- a/Sources/Site/Music/Music+URL.swift
+++ b/Sources/Site/Music/Music+URL.swift
@@ -8,18 +8,24 @@
 import Foundation
 import os
 
+extension Logger {
+  nonisolated(unsafe) static let url = Logger(category: "url")
+  nonisolated(unsafe) static let music = Logger(category: "music")
+#if swift(>=6.0)
+  #warning("nonisolated(unsafe) unneeded.")
+#endif
+}
+
 extension Music {
   public static func load(url: URL) async throws -> Music {
-    let musicLogger = Logger(category: "music")
-    musicLogger.log("start")
+    Logger.music.log("start")
     defer {
-      musicLogger.log("end")
+      Logger.music.log("end")
     }
 
-    let urlLogger = Logger(category: "url")
-    urlLogger.log("start: \(url.absoluteString, privacy: .public)")
+    Logger.url.log("start: \(url.absoluteString, privacy: .public)")
     let (data, _) = try await URLSession.shared.data(from: url)
-    urlLogger.log("end")
+    Logger.url.log("end")
 
     let music: Music = try data.fromJSON()
     return music

--- a/Sources/Site/Music/SiteModel.swift
+++ b/Sources/Site/Music/SiteModel.swift
@@ -8,13 +8,18 @@
 import Foundation
 import os
 
+extension Logger {
+  nonisolated(unsafe) static let vaultLoader = Logger(category: "vaultLoader")
+#if swift(>=6.0)
+  #warning("nonisolated(unsafe) unneeded.")
+#endif
+}
+
 @Observable public final class SiteModel {
   private let urlString: String
 
   public var vaultModel: VaultModel?
   internal var error: Error?
-
-  private let vaultLoader = Logger(category: "vaultLoader")
 
   public init(urlString: String, vaultModel: VaultModel? = nil, error: Error? = nil) {
     self.urlString = urlString
@@ -24,9 +29,9 @@ import os
 
   @MainActor
   public func load() async {
-    vaultLoader.log("start")
+    Logger.vaultLoader.log("start")
     defer {
-      vaultLoader.log("end")
+      Logger.vaultLoader.log("end")
     }
     do {
       error = nil
@@ -36,7 +41,7 @@ import os
       vaultModel?.cancelTasks()
       vaultModel = VaultModel(vault)
     } catch {
-      vaultLoader.fault("error: \(error.localizedDescription, privacy: .public)")
+      Logger.vaultLoader.fault("error: \(error.localizedDescription, privacy: .public)")
       self.error = error
     }
   }

--- a/Sources/Site/Music/UI/ArchiveCategorySplit.swift
+++ b/Sources/Site/Music/UI/ArchiveCategorySplit.swift
@@ -9,6 +9,13 @@ import CoreLocation
 import SwiftUI
 import os
 
+extension Logger {
+  nonisolated(unsafe) static let link = Logger(category: "link")
+  #if swift(>=6.0)
+    #warning("nonisolated(unsafe) unneeded.")
+  #endif
+}
+
 struct ArchiveCategorySplit: View {
   var model: VaultModel
 
@@ -67,36 +74,32 @@ struct ArchiveCategorySplit: View {
     }
     .archiveStorage(archiveNavigation: archiveNavigation)
     .onContinueUserActivity(ArchivePath.activityType) { userActivity in
-      let decodeActivityLogger = Logger(category: "decodeActivity")
       do {
-        archiveNavigation.navigate(to: try userActivity.archivePath(decodeActivityLogger))
+        archiveNavigation.navigate(to: try userActivity.archivePath())
       } catch {
-        decodeActivityLogger.error("error: \(error, privacy: .public)")
+        Logger.decodeActivity.error("error: \(error, privacy: .public)")
       }
     }
     .onContinueUserActivity(ArchiveCategory.activityType) { userActivity in
-      let decodeCategoryActivityLogger = Logger(category: "decodeCategoryActivity")
       do {
-        archiveNavigation.navigate(
-          to: try userActivity.archiveCategory(decodeCategoryActivityLogger))
+        archiveNavigation.navigate(to: try userActivity.archiveCategory())
       } catch {
-        decodeCategoryActivityLogger.error("error: \(error, privacy: .public)")
+        Logger.decodeActivity.error("error: \(error, privacy: .public)")
       }
     }
     .onOpenURL { url in
-      let link = Logger(category: "link")
-      link.log("url: \(url.absoluteString, privacy: .public)")
+      Logger.link.log("url: \(url.absoluteString, privacy: .public)")
       do {
         let archivePath = try ArchivePath(url)
         archiveNavigation.navigate(to: archivePath)
       } catch {
-        link.error("ArchivePath to URL error: \(error, privacy: .public)")
+        Logger.link.error("ArchivePath to URL error: \(error, privacy: .public)")
 
         do {
           let archiveCategory = try ArchiveCategory(url)
           archiveNavigation.navigate(to: archiveCategory)
         } catch {
-          link.error("ArchiveCategory to URL error: \(error, privacy: .public)")
+          Logger.link.error("ArchiveCategory to URL error: \(error, privacy: .public)")
         }
       }
     }

--- a/Sources/Site/Music/UI/ArchiveNavigation.swift
+++ b/Sources/Site/Music/UI/ArchiveNavigation.swift
@@ -8,13 +8,18 @@
 import Foundation
 import os
 
+extension Logger {
+  nonisolated(unsafe) static let archive = Logger(category: "archive")
+  #if swift(>=6.0)
+    #warning("nonisolated(unsafe) unneeded.")
+  #endif
+}
+
 @Observable final class ArchiveNavigation {
   internal var selectedCategory: ArchiveCategory?
   internal var navigationPath: [ArchivePath] = []
 
   @ObservationIgnored internal var pendingNavigationPath: [ArchivePath]?
-
-  private let archive = Logger(category: "archive")
 
   func restoreNavigation(selectedCategoryStorage: ArchiveCategory?, pathData: Data?) {
     if let selectedCategoryStorage {
@@ -22,7 +27,7 @@ import os
         // Hold onto the loading navigationPath for after the selectedCategory changes.
         var pending = [ArchivePath]()
         pending.jsonData = pathData
-        archive.log(
+        Logger.archive.log(
           "pending save: \(pending.map { $0.formatted() }.joined(separator: ":"), privacy: .public)"
         )
         pendingNavigationPath = pending
@@ -40,7 +45,7 @@ import os
   func restorePendingData() {
     // Change the navigationPath after selectedCategory changes.
     if let pendingNavigationPath {
-      archive.log("pending restore")
+      Logger.archive.log("pending restore")
       navigationPath = pendingNavigationPath
       self.pendingNavigationPath = nil
     }
@@ -48,15 +53,15 @@ import os
 
   func navigate(to path: ArchivePath) {
     guard path != navigationPath.last else {
-      archive.log("already presented: \(path.formatted(), privacy: .public)")
+      Logger.archive.log("already presented: \(path.formatted(), privacy: .public)")
       return
     }
-    archive.log("nav to path: \(path.formatted(), privacy: .public)")
+    Logger.archive.log("nav to path: \(path.formatted(), privacy: .public)")
     navigationPath.append(path)
   }
 
   func navigate(to category: ArchiveCategory?) {
-    archive.log("nav to category: \(category?.rawValue ?? "nil", privacy: .public)")
+    Logger.archive.log("nav to category: \(category?.rawValue ?? "nil", privacy: .public)")
     selectedCategory = category
   }
 }

--- a/Sources/Site/Music/UI/ArchiveStorageModifier.swift
+++ b/Sources/Site/Music/UI/ArchiveStorageModifier.swift
@@ -8,9 +8,15 @@
 import SwiftUI
 import os
 
+extension Logger {
+  nonisolated(unsafe) static let storage = Logger(category: "storage")
+  #if swift(>=6.0)
+    #warning("nonisolated(unsafe) unneeded.")
+  #endif
+}
+
 struct ArchiveStorageModifier: ViewModifier {
   let archiveNavigation: ArchiveNavigation
-  private let storage = Logger(category: "storage")
 
   @SceneStorage("selected.category") private var selectedCategoryStorage: String?
   @SceneStorage("navigation.path") private var navigationPathData: Data?
@@ -18,9 +24,9 @@ struct ArchiveStorageModifier: ViewModifier {
   func body(content: Content) -> some View {
     content
       .task {
-        storage.log("start restore")
+        Logger.storage.log("start restore")
         defer {
-          storage.log("end restore")
+          Logger.storage.log("end restore")
         }
         let archiveCategory =
           selectedCategoryStorage != nil ? ArchiveCategory(rawValue: selectedCategoryStorage!) : nil
@@ -28,13 +34,13 @@ struct ArchiveStorageModifier: ViewModifier {
           selectedCategoryStorage: archiveCategory, pathData: navigationPathData)
       }
       .onChange(of: archiveNavigation.selectedCategory) { _, newValue in
-        storage.log("category: \(newValue?.rawValue ?? "nil", privacy: .public)")
+        Logger.storage.log("category: \(newValue?.rawValue ?? "nil", privacy: .public)")
         selectedCategoryStorage = newValue?.rawValue ?? nil
 
         archiveNavigation.restorePendingData()
       }
       .onChange(of: archiveNavigation.navigationPath) { _, newPath in
-        storage.log(
+        Logger.storage.log(
           "path: \(newPath.map { $0.formatted() }.joined(separator: ":"), privacy: .public)")
         navigationPathData = newPath.jsonData
       }

--- a/Sources/Site/Music/UI/NotificationModifier.swift
+++ b/Sources/Site/Music/UI/NotificationModifier.swift
@@ -6,18 +6,24 @@
 //
 
 import SwiftUI
-@preconcurrency import os
+import os
+
+extension Logger {
+  nonisolated(unsafe) static let notification = Logger(category: "notification")
+#if swift(>=6.0)
+  #warning("nonisolated(unsafe) unneeded.")
+#endif
+}
 
 struct NotificationModifier: ViewModifier {
   let name: Notification.Name
   let action: @MainActor @Sendable () -> Void
-  private let notification = Logger(category: "notification")
 
   private func mainDeferredAction() {
     // This Task / @MainActor seems to accomplish a similar DispatchQueue.main.async feel.
     // Still not clear to me why this is necessary in SwiftUI.
     Task {
-      notification.log("main action: \(name.rawValue, privacy: .public)")
+      Logger.notification.log("main action: \(name.rawValue, privacy: .public)")
       await action()
     }
   }
@@ -25,10 +31,10 @@ struct NotificationModifier: ViewModifier {
   func body(content: Content) -> some View {
     content
       .task {
-        notification.log("task: \(name.rawValue, privacy: .public)")
+        Logger.notification.log("task: \(name.rawValue, privacy: .public)")
         mainDeferredAction()
         for await _ in NotificationCenter.default.notifications(named: name).map({ $0.name }) {
-          notification.log("notified: \(name.rawValue, privacy: .public)")
+          Logger.notification.log("notified: \(name.rawValue, privacy: .public)")
           mainDeferredAction()
         }
       }

--- a/Sources/Site/Music/UI/SiteView.swift
+++ b/Sources/Site/Music/UI/SiteView.swift
@@ -8,9 +8,15 @@
 import SwiftUI
 import os
 
+extension Logger {
+  nonisolated(unsafe) static let vaultLoad = Logger(category: "vaultLoad")
+  #if swift(>=6.0)
+    #warning("nonisolated(unsafe) unneeded.")
+  #endif
+}
+
 public struct SiteView: View {
   private var model: SiteModel
-  private let vaultLoad = Logger(category: "vaultLoad")
 
   public init(_ model: SiteModel) {
     self.model = model
@@ -21,9 +27,9 @@ public struct SiteView: View {
       if let vaultModel = model.vaultModel {
         ArchiveCategorySplit(model: vaultModel)
           .refreshable {
-            vaultLoad.log("start refresh")
+            Logger.vaultLoad.log("start refresh")
             defer {
-              vaultLoad.log("end refresh")
+              Logger.vaultLoad.log("end refresh")
             }
             await model.load()
           }
@@ -34,7 +40,7 @@ public struct SiteView: View {
             description: Text("Unable to load data.", bundle: .module))
           Button {
             Task {
-              vaultLoad.log("User retry")
+              Logger.vaultLoad.log("User retry")
               await model.load()
             }
           } label: {
@@ -48,9 +54,9 @@ public struct SiteView: View {
     }.task {
       guard model.vaultModel == nil, model.error == nil else { return }
 
-      vaultLoad.log("start task")
+      Logger.vaultLoad.log("start task")
       defer {
-        vaultLoad.log("end task")
+        Logger.vaultLoad.log("end task")
       }
       await model.load()
     }

--- a/Sources/Site/Music/Vault+URL.swift
+++ b/Sources/Site/Music/Vault+URL.swift
@@ -8,6 +8,13 @@
 import Foundation
 import os
 
+extension Logger {
+  nonisolated(unsafe) static let vault = Logger(category: "vault")
+  #if swift(>=6.0)
+    #warning("nonisolated(unsafe) unneeded.")
+  #endif
+}
+
 enum VaultError: Error {
   case illegalURL(String)
 }
@@ -29,10 +36,9 @@ extension Vault {
   }
 
   public static func load(url: URL, artistsWithShowsOnly: Bool = true) async throws -> Vault {
-    let vault = Logger(category: "vault")
-    vault.log("start")
+    Logger.vault.log("start")
     defer {
-      vault.log("end")
+      Logger.vault.log("end")
     }
     let music = try await Music.load(url: url)
     return await Vault.create(music: artistsWithShowsOnly ? music.showsOnly : music, url: url)

--- a/Sources/Site/Utility/Data+JSON.swift
+++ b/Sources/Site/Utility/Data+JSON.swift
@@ -8,12 +8,18 @@
 import Foundation
 import os
 
+extension Logger {
+  nonisolated(unsafe) static let json = Logger(category: "json")
+  #if swift(>=6.0)
+    #warning("nonisolated(unsafe) unneeded.")
+  #endif
+}
+
 extension Data {
   public func fromJSON<T>() throws -> T where T: Decodable {
-    let json = Logger(category: "json")
-    json.log("start")
+    Logger.json.log("start")
     defer {
-      json.log("end")
+      Logger.json.log("end")
     }
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601


### PR DESCRIPTION
Fixes #824

Revert "Convert Link Logger to a local variable (#762)"

This reverts commit 1edd225d494cca3ff5b7a18cb43c0671b9d52cb2.

Revert "Convert Archive Logger to an instance property (#763)"

This reverts commit fd6323a9bb869feecd54394f3ce76e92671eeb8c.

Revert "Convert Storage Logger to an instance property (#764)"

This reverts commit cd3e5ebc71192bf9fb3e110ea8a1af86e63aac5e.

Revert "Convert VaultLoad Logger to an instance property (#765)"

This reverts commit 160d1d3bb7346af10b1dcbfd7855513d0541decb.

Revert "Convert AtlasCache Logger to an instance property (#767)"

This reverts commit d053bf693ddf7a123d263246422b4057762858d5.

Revert "Convert Atlas Logger to an instance property (#766)"

This reverts commit 231461c6ba96da7912bdc76856931e42946c2e0e.

Revert "Convert vault Logger to a local variable (#771)"

This reverts commit 6d654d5467d9730354584d236171865f3576c556.

Revert "VaultModel logger is now an instance property (#770)"

This reverts commit 1480c7ffd03eda971dfd4bbaf835a2c768ce1ea6.

Revert "Convert json Logger to a local variable (#769)"

This reverts commit 66281a30251909c4bd7265289fa73892abe33ede.

Revert "Location logger is now an instance property (#768)"

This reverts commit d6d2dff65abfb20d0d0148131bc2d574078eaefe.

Revert "Convert lookup Logger to an instance variable (#773)"

This reverts commit b26b0c3a149c91dabf9c9b0ad7c1d6506575d9b3.

Revert "Convert vaultLoader Logger to an instance variable (#772)"

This reverts commit 5afd7d7f76d4d55f5712fec027dd2c792516d950.

Revert "use local variables for Music loading logging (#774)"

This reverts commit 9e47bd1973a496b9d7ceba3ba03bb0ccfe1acef9.

Revert "Convert Notification Logger to an instance property (#780)"

This reverts commit 763ec1083ff91b3b9941925479f7340818b06a37.

Revert "updateActivity logger is now a local variable (#779)"

This reverts commit f38974ecdc20efeb4f59a921c10eacf558738e9a.

Revert "updateCategoryActivity logger is now a local variable (#778)"

This reverts commit 16eb99884be7e33565b0308813097a3719e72b48.

Revert "decode activity logger for path is now a local variable (#777)"

This reverts commit a9bb36d84611fadbeb5a8658cbd902d718547c3b.

Revert "decode category activity logger is a local variable (#776)"

This reverts commit c8646e21a25b458d87ac5a12a2b33f27fd0a2cbf.

Revert "os.Logger is preconcurrency (#775)"

This reverts commit 486af526316fa6cc54ba9f742834a826a3dd0e5d.