### PR TITLE
ArchiveNavigation.restoreNavigation allows selectedCategory to be set to nil

### DIFF
--- a/Sources/Site/Music/UI/ArchiveNavigation.swift
+++ b/Sources/Site/Music/UI/ArchiveNavigation.swift
@@ -28,24 +28,18 @@ extension Logger {
   }
 
   func restoreNavigation(selectedCategoryStorage: ArchiveCategory?, pathData: Data?) {
-    if let selectedCategoryStorage {
-      if let pathData {
-        // Hold onto the loading navigationPath for after the selectedCategory changes.
-        var pending = [ArchivePath]()
-        pending.jsonData = pathData
-        Logger.archive.log(
-          "pending save: \(pending.map { $0.formatted() }.joined(separator: ":"), privacy: .public)"
-        )
-        pendingNavigationPath = pending
-      }
-
-      // Changing the selectedCategory will reset the NavigationStack's navigationPath.
-      selectedCategory = selectedCategoryStorage
-    } else {
-      if let pathData {
-        navigationPath.jsonData = pathData
-      }
+    if let pathData {
+      // Hold onto the loading navigationPath for after the selectedCategory changes.
+      var pending = [ArchivePath]()
+      pending.jsonData = pathData
+      Logger.archive.log(
+        "pending save: \(pending.map { $0.formatted() }.joined(separator: ":"), privacy: .public)"
+      )
+      pendingNavigationPath = pending
     }
+
+    // Changing the selectedCategory will reset the NavigationStack's navigationPath.
+    selectedCategory = selectedCategoryStorage
   }
 
   func restorePendingData() {

--- a/Tests/SiteTests/ArchiveNavigationTests.swift
+++ b/Tests/SiteTests/ArchiveNavigationTests.swift
@@ -78,11 +78,13 @@ final class ArchiveNavigationTests: XCTestCase {
     XCTAssertNil(ar.selectedCategory)
     XCTAssertNotEqual(ar.selectedCategory, .today)
 
-    XCTAssertFalse(ar.navigationPath.isEmpty)
-    XCTAssertNotNil(ar.navigationPath.first)
-    XCTAssertEqual(ar.navigationPath.first!, ArchivePath.artist("id"))
+    XCTAssertNotNil(ar.navigationPath)
+    XCTAssertTrue(ar.navigationPath.isEmpty)
 
-    XCTAssertNil(ar.pendingNavigationPath)
+    XCTAssertNotNil(ar.pendingNavigationPath)
+    XCTAssertEqual(ar.pendingNavigationPath?.count, 1)
+    XCTAssertNotNil(ar.pendingNavigationPath?.first)
+    XCTAssertEqual(ar.pendingNavigationPath?.first!, ArchivePath.artist("id"))
   }
 
   func testRestoreNavigation_nilCategoryAndTruePath_existing() throws {
@@ -92,14 +94,16 @@ final class ArchiveNavigationTests: XCTestCase {
     let pathData = [ArchivePath.artist("id")].jsonData
     ar.restoreNavigation(selectedCategoryStorage: nil, pathData: pathData)
 
-    XCTAssertNotNil(ar.selectedCategory)
-    XCTAssertEqual(ar.selectedCategory!, .stats)
+    XCTAssertNil(ar.selectedCategory)
 
     XCTAssertFalse(ar.navigationPath.isEmpty)
     XCTAssertNotNil(ar.navigationPath.first)
-    XCTAssertEqual(ar.navigationPath.first!, ArchivePath.artist("id"))
+    XCTAssertEqual(ar.navigationPath.first!, ArchivePath.venue("vid"))
 
-    XCTAssertNil(ar.pendingNavigationPath)
+    XCTAssertNotNil(ar.pendingNavigationPath)
+    XCTAssertEqual(ar.pendingNavigationPath?.count, 1)
+    XCTAssertNotNil(ar.pendingNavigationPath?.first)
+    XCTAssertEqual(ar.pendingNavigationPath?.first!, ArchivePath.artist("id"))
   }
 
   func testRestoreNavigation_trueCategoryAndNilPath() throws {
@@ -138,8 +142,7 @@ final class ArchiveNavigationTests: XCTestCase {
 
     ar.restoreNavigation(selectedCategoryStorage: nil, pathData: nil)
 
-    XCTAssertNotNil(ar.selectedCategory)
-    XCTAssertEqual(ar.selectedCategory, .stats)
+    XCTAssertNil(ar.selectedCategory)
 
     XCTAssertFalse(ar.navigationPath.isEmpty)
     XCTAssertNotNil(ar.navigationPath.first)

--- a/Tests/SiteTests/ArchiveNavigationTests.swift
+++ b/Tests/SiteTests/ArchiveNavigationTests.swift
@@ -76,7 +76,6 @@ final class ArchiveNavigationTests: XCTestCase {
     ar.restoreNavigation(selectedCategoryStorage: nil, pathData: pathData)
 
     XCTAssertNil(ar.selectedCategory)
-    XCTAssertNotEqual(ar.selectedCategory, .today)
 
     XCTAssertNotNil(ar.navigationPath)
     XCTAssertTrue(ar.navigationPath.isEmpty)
@@ -128,7 +127,6 @@ final class ArchiveNavigationTests: XCTestCase {
     ar.restoreNavigation(selectedCategoryStorage: nil, pathData: nil)
 
     XCTAssertNil(ar.selectedCategory)
-    XCTAssertNotEqual(ar.selectedCategory, .today)
 
     XCTAssertTrue(ar.navigationPath.isEmpty)
     XCTAssertNil(ar.navigationPath.first)


### PR DESCRIPTION
- Any navigationPath will then be pending, not set immediately.