### PR TITLE
ArchiveNavigation.restoreNavigation with nil category clears the path

### DIFF
--- a/Sources/Site/Music/UI/ArchiveNavigation.swift
+++ b/Sources/Site/Music/UI/ArchiveNavigation.swift
@@ -28,6 +28,12 @@ extension Logger {
   }
 
   func restoreNavigation(selectedCategoryStorage: ArchiveCategory?, pathData: Data?) {
+    guard let selectedCategoryStorage else {
+      selectedCategory = nil
+      pendingNavigationPath = []
+      return
+    }
+
     if let pathData {
       // Hold onto the loading navigationPath for after the selectedCategory changes.
       var pending = [ArchivePath]()

--- a/Tests/SiteTests/ArchiveNavigationTests.swift
+++ b/Tests/SiteTests/ArchiveNavigationTests.swift
@@ -81,9 +81,7 @@ final class ArchiveNavigationTests: XCTestCase {
     XCTAssertTrue(ar.navigationPath.isEmpty)
 
     XCTAssertNotNil(ar.pendingNavigationPath)
-    XCTAssertEqual(ar.pendingNavigationPath?.count, 1)
-    XCTAssertNotNil(ar.pendingNavigationPath?.first)
-    XCTAssertEqual(ar.pendingNavigationPath?.first!, ArchivePath.artist("id"))
+    XCTAssertEqual(ar.pendingNavigationPath?.count, 0)
   }
 
   func testRestoreNavigation_nilCategoryAndTruePath_existing() throws {
@@ -100,9 +98,7 @@ final class ArchiveNavigationTests: XCTestCase {
     XCTAssertEqual(ar.navigationPath.first!, ArchivePath.venue("vid"))
 
     XCTAssertNotNil(ar.pendingNavigationPath)
-    XCTAssertEqual(ar.pendingNavigationPath?.count, 1)
-    XCTAssertNotNil(ar.pendingNavigationPath?.first)
-    XCTAssertEqual(ar.pendingNavigationPath?.first!, ArchivePath.artist("id"))
+    XCTAssertEqual(ar.pendingNavigationPath?.count, 0)
   }
 
   func testRestoreNavigation_trueCategoryAndNilPath() throws {
@@ -131,7 +127,8 @@ final class ArchiveNavigationTests: XCTestCase {
     XCTAssertTrue(ar.navigationPath.isEmpty)
     XCTAssertNil(ar.navigationPath.first)
 
-    XCTAssertNil(ar.pendingNavigationPath)
+    XCTAssertNotNil(ar.pendingNavigationPath)
+    XCTAssertEqual(ar.pendingNavigationPath?.count, 0)
   }
 
   func testRestoreNavigation_nilCategoryAndNilPath_existing() throws {
@@ -146,7 +143,8 @@ final class ArchiveNavigationTests: XCTestCase {
     XCTAssertNotNil(ar.navigationPath.first)
     XCTAssertEqual(ar.navigationPath.first!, ArchivePath.venue("vid"))
 
-    XCTAssertNil(ar.pendingNavigationPath)
+    XCTAssertNotNil(ar.pendingNavigationPath)
+    XCTAssertEqual(ar.pendingNavigationPath?.count, 0)
   }
 
   func testRestorePendingData() throws {


### PR DESCRIPTION
- logicalliy with no category selected, there cannot be a navigationPath.