### PR TITLE
VenueDetail no longer needs to know about CLPlacemark

### DIFF
--- a/Sources/Site/Music/UI/VenueDetail.swift
+++ b/Sources/Site/Music/UI/VenueDetail.swift
@@ -5,11 +5,8 @@
 //  Created by Greg Bolsinga on 2/16/23.
 //
 
-@preconcurrency import CoreLocation  // CLPlacemark not @Sendable
 import MapKit
 import SwiftUI
-
-extension CLPlacemark: Identifiable {}
 
 struct VenueDetail: View {
   typealias geocoder = (VenueDigest) async throws -> CLPlacemark


### PR DESCRIPTION
follow up to #738. Xcode16 RC warned about declaring CLPlacemark was Identifiable, when the library may change that in the future.