### PR TITLE
ArchiveNavigation.State is now a private property

### DIFF
--- a/Sources/Site/Music/UI/ArchiveNavigation.swift
+++ b/Sources/Site/Music/UI/ArchiveNavigation.swift
@@ -31,10 +31,28 @@ extension Logger {
     }
   }
 
-  var state: State
+  private var state: State
 
   internal init(_ state: State = State()) {
     self.state = state
+  }
+
+  var category: ArchiveNavigation.State.DefaultCategory {
+    get {
+      state.category
+    }
+    set {
+      state.category = newValue
+    }
+  }
+
+  var path: [ArchivePath] {
+    get {
+      state.path
+    }
+    set {
+      state.path = newValue
+    }
   }
 
   func navigate(to path: ArchivePath) {

--- a/Sources/Site/Music/UI/ArchiveStateView.swift
+++ b/Sources/Site/Music/UI/ArchiveStateView.swift
@@ -29,8 +29,8 @@ struct ArchiveStateView: View {
   @ViewBuilder private var archiveBody: some View {
     ArchiveCategorySplit(
       model: model, venueSort: $venueSort, artistSort: $artistSort,
-      selectedCategory: $archiveNavigation.state.category,
-      path: $archiveNavigation.state.path, nearbyModel: nearbyModel)
+      selectedCategory: $archiveNavigation.category,
+      path: $archiveNavigation.path, nearbyModel: nearbyModel)
   }
 
   var body: some View {

--- a/Tests/SiteTests/ArchiveNavigationTests.swift
+++ b/Tests/SiteTests/ArchiveNavigationTests.swift
@@ -13,35 +13,35 @@ struct ArchiveNavigationTests {
   @Test func navigateToCategory() {
     let ar = ArchiveNavigation()
     #if os(iOS) || os(tvOS)
-      #expect(ar.state.category != nil)
+      #expect(ar.category != nil)
     #endif
-    #expect(ar.state.category == ArchiveNavigation.State.defaultCategory)
-    #expect(ar.state.path.isEmpty)
+    #expect(ar.category == ArchiveNavigation.State.defaultCategory)
+    #expect(ar.path.isEmpty)
 
     ar.navigate(to: .today)
-    #expect(ar.state.category == .today)
-    #expect(ar.state.path.isEmpty)
+    #expect(ar.category == .today)
+    #expect(ar.path.isEmpty)
 
     ar.navigate(to: .stats)
-    #expect(ar.state.category == .stats)
-    #expect(ar.state.path.isEmpty)
+    #expect(ar.category == .stats)
+    #expect(ar.path.isEmpty)
 
     ar.navigate(to: .artists)
-    #expect(ar.state.category == .artists)
-    #expect(ar.state.path.isEmpty)
+    #expect(ar.category == .artists)
+    #expect(ar.path.isEmpty)
 
     ar.navigate(to: .venues)
-    #expect(ar.state.category == .venues)
-    #expect(ar.state.path.isEmpty)
+    #expect(ar.category == .venues)
+    #expect(ar.path.isEmpty)
 
     ar.navigate(to: .shows)
-    #expect(ar.state.category == .shows)
-    #expect(ar.state.path.isEmpty)
+    #expect(ar.category == .shows)
+    #expect(ar.path.isEmpty)
 
     #if os(iOS) || os(tvOS)
       ar.navigate(to: nil)
-      #expect(ar.state.category == nil)
-      #expect(ar.state.path.isEmpty)
+      #expect(ar.category == nil)
+      #expect(ar.path.isEmpty)
     #endif
   }
 
@@ -50,87 +50,87 @@ struct ArchiveNavigationTests {
       ArchiveNavigation.State(
         category: .artists, path: [Artist(id: "id", name: "name").archivePath]))
     #if os(iOS) || os(tvOS)
-      #expect(ar.state.category != nil)
+      #expect(ar.category != nil)
     #endif
-    #expect(ar.state.category == .artists)
-    #expect(!ar.state.path.isEmpty)
-    #expect(ar.state.path.first! == Artist(id: "id", name: "name").archivePath)
+    #expect(ar.category == .artists)
+    #expect(!ar.path.isEmpty)
+    #expect(ar.path.first! == Artist(id: "id", name: "name").archivePath)
 
     ar.navigate(to: .venues)
     #if os(iOS) || os(tvOS)
-      #expect(ar.state.category != nil)
+      #expect(ar.category != nil)
     #endif
-    #expect(ar.state.category == .venues)
-    #expect(ar.state.path.isEmpty)
+    #expect(ar.category == .venues)
+    #expect(ar.path.isEmpty)
   }
 
   @Test func navigateToArchivePath() {
     let ar = ArchiveNavigation()
     #if os(iOS) || os(tvOS)
-      #expect(ar.state.category != nil)
+      #expect(ar.category != nil)
     #endif
-    #expect(ar.state.category == ArchiveNavigation.State.defaultCategory)
-    #expect(ar.state.path.isEmpty)
+    #expect(ar.category == ArchiveNavigation.State.defaultCategory)
+    #expect(ar.path.isEmpty)
 
     ar.navigate(to: ArchivePath.artist("id"))
     #if os(iOS) || os(tvOS)
-      #expect(ar.state.category != nil)
+      #expect(ar.category != nil)
     #endif
-    #expect(ar.state.category == ArchiveNavigation.State.defaultCategory)
-    #expect(ar.state.path.count == 1)
-    #expect(ar.state.path.last != nil)
-    #expect(ar.state.path.last! == ArchivePath.artist("id"))
+    #expect(ar.category == ArchiveNavigation.State.defaultCategory)
+    #expect(ar.path.count == 1)
+    #expect(ar.path.last != nil)
+    #expect(ar.path.last! == ArchivePath.artist("id"))
 
     ar.navigate(to: ArchivePath.venue("id"))
     #if os(iOS) || os(tvOS)
-      #expect(ar.state.category != nil)
+      #expect(ar.category != nil)
     #endif
-    #expect(ar.state.category == ArchiveNavigation.State.defaultCategory)
-    #expect(ar.state.path.count == 2)
-    #expect(ar.state.path.last != nil)
-    #expect(ar.state.path.last! == ArchivePath.venue("id"))
+    #expect(ar.category == ArchiveNavigation.State.defaultCategory)
+    #expect(ar.path.count == 2)
+    #expect(ar.path.last != nil)
+    #expect(ar.path.last! == ArchivePath.venue("id"))
 
     ar.navigate(to: ArchivePath.show("id"))
     #if os(iOS) || os(tvOS)
-      #expect(ar.state.category != nil)
+      #expect(ar.category != nil)
     #endif
-    #expect(ar.state.category == ArchiveNavigation.State.defaultCategory)
-    #expect(ar.state.path.count == 3)
-    #expect(ar.state.path.last != nil)
-    #expect(ar.state.path.last! == ArchivePath.show("id"))
+    #expect(ar.category == ArchiveNavigation.State.defaultCategory)
+    #expect(ar.path.count == 3)
+    #expect(ar.path.last != nil)
+    #expect(ar.path.last! == ArchivePath.show("id"))
 
     ar.navigate(to: ArchivePath.year(Annum.year(1989)))
     #if os(iOS) || os(tvOS)
-      #expect(ar.state.category != nil)
+      #expect(ar.category != nil)
     #endif
-    #expect(ar.state.category == ArchiveNavigation.State.defaultCategory)
-    #expect(ar.state.path.count == 4)
-    #expect(ar.state.path.last != nil)
-    #expect(ar.state.path.last! == ArchivePath.year(Annum.year(1989)))
+    #expect(ar.category == ArchiveNavigation.State.defaultCategory)
+    #expect(ar.path.count == 4)
+    #expect(ar.path.last != nil)
+    #expect(ar.path.last! == ArchivePath.year(Annum.year(1989)))
   }
 
   @Test func navigateToArchivePath_noDoubles() {
     let ar = ArchiveNavigation()
     ar.navigate(to: ArchivePath.artist("id"))
-    #expect(ar.state.path.count == 1)
-    #expect(ar.state.path.first! == ArchivePath.artist("id"))
-    #expect(ar.state.category == ArchiveNavigation.State.defaultCategory)
+    #expect(ar.path.count == 1)
+    #expect(ar.path.first! == ArchivePath.artist("id"))
+    #expect(ar.category == ArchiveNavigation.State.defaultCategory)
 
     ar.navigate(to: ArchivePath.artist("id"))
-    #expect(ar.state.path.count == 1)
-    #expect(ar.state.path.first! == ArchivePath.artist("id"))
-    #expect(ar.state.category == ArchiveNavigation.State.defaultCategory)
+    #expect(ar.path.count == 1)
+    #expect(ar.path.first! == ArchivePath.artist("id"))
+    #expect(ar.category == ArchiveNavigation.State.defaultCategory)
 
     ar.navigate(to: ArchivePath.artist("id-1"))
-    #expect(ar.state.path.count == 2)
-    #expect(ar.state.path.first! == ArchivePath.artist("id"))
-    #expect(ar.state.path.last! == ArchivePath.artist("id-1"))
-    #expect(ar.state.category == ArchiveNavigation.State.defaultCategory)
+    #expect(ar.path.count == 2)
+    #expect(ar.path.first! == ArchivePath.artist("id"))
+    #expect(ar.path.last! == ArchivePath.artist("id-1"))
+    #expect(ar.category == ArchiveNavigation.State.defaultCategory)
 
     ar.navigate(to: ArchivePath.venue("vid-1"))
-    #expect(ar.state.path.count == 3)
-    #expect(ar.state.path.first! == ArchivePath.artist("id"))
-    #expect(ar.state.path.last! == ArchivePath.venue("vid-1"))
-    #expect(ar.state.category == ArchiveNavigation.State.defaultCategory)
+    #expect(ar.path.count == 3)
+    #expect(ar.path.first! == ArchivePath.artist("id"))
+    #expect(ar.path.last! == ArchivePath.venue("vid-1"))
+    #expect(ar.category == ArchiveNavigation.State.defaultCategory)
   }
 }


### PR DESCRIPTION
Add accessor methods. The goal is to hide the serialization so it can change.