### PR TITLE
Store each category's path

### DIFF
--- a/Sources/Site/Music/UI/ArchiveNavigation.swift
+++ b/Sources/Site/Music/UI/ArchiveNavigation.swift
@@ -23,11 +23,14 @@ extension Logger {
     #endif
 
     var category: DefaultCategory
-    var path: [ArchivePath]
+    var categoryPaths: [ArchiveCategory: [ArchivePath]]
 
-    internal init(category: DefaultCategory = defaultCategory, path: [ArchivePath] = []) {
+    internal init(
+      category: DefaultCategory = defaultCategory,
+      categoryPaths: [ArchiveCategory: [ArchivePath]] = [:]
+    ) {
       self.category = category
-      self.path = path
+      self.categoryPaths = categoryPaths
     }
   }
 
@@ -48,10 +51,16 @@ extension Logger {
 
   var path: [ArchivePath] {
     get {
-      state.path
+      #if os(iOS) || os(tvOS)
+        guard let category = state.category else { return [] }
+      #endif
+      return state.categoryPaths[category] ?? []
     }
     set {
-      state.path = newValue
+      #if os(iOS) || os(tvOS)
+        guard let category = state.category else { return }
+      #endif
+      state.categoryPaths[category] = newValue
     }
   }
 

--- a/Tests/SiteTests/ArchiveNavigationTests.swift
+++ b/Tests/SiteTests/ArchiveNavigationTests.swift
@@ -48,7 +48,8 @@ struct ArchiveNavigationTests {
   @Test func navigateToCategory_existingPath() {
     let ar = ArchiveNavigation(
       ArchiveNavigation.State(
-        category: .artists, path: [Artist(id: "id", name: "name").archivePath]))
+        category: .artists, categoryPaths: [.artists: [Artist(id: "id", name: "name").archivePath]])
+    )
     #if os(iOS) || os(tvOS)
       #expect(ar.category != nil)
     #endif


### PR DESCRIPTION
This way the each category has its own path, making this a little better. It will also work better for tabs, which will have multiple NavigationStack paths.