### PR TITLE
Add category/path test

### DIFF
--- a/Tests/SiteTests/ArchiveNavigationTests.swift
+++ b/Tests/SiteTests/ArchiveNavigationTests.swift
@@ -63,6 +63,13 @@ struct ArchiveNavigationTests {
     #endif
     #expect(ar.category == .venues)
     #expect(ar.path.isEmpty)
+
+    ar.navigate(to: .artists)
+    #if os(iOS) || os(tvOS)
+      #expect(ar.category != nil)
+    #endif
+    #expect(ar.category == .artists)
+    #expect(ar.path.isEmpty)
   }
 
   @Test func navigateToArchivePath() {


### PR DESCRIPTION
- This tests what happens when ArchiveNavigation moves from one category with a path to another category, and then back.
- Basicallly what happens is the path is cleared. This is likely not preferred behavior going forward.