### PR TITLE
Add NearbyModel.State

### DIFF
--- a/Sources/Site/Music/LocationFilter.swift
+++ b/Sources/Site/Music/LocationFilter.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum LocationFilter: Int {
+enum LocationFilter: Int, Codable {
   case none
   case nearby
 

--- a/Sources/Site/Music/NearbyModel.swift
+++ b/Sources/Site/Music/NearbyModel.swift
@@ -7,13 +7,66 @@
 
 import CoreLocation
 import Foundation
+import os
+
+extension Logger {
+  fileprivate static let nearby = Logger(category: "nearby")
+}
 
 @Observable final class NearbyModel {
-  internal var distanceThreshold: CLLocationDistance
-  internal var locationFilter: LocationFilter
+  struct State: Codable, Equatable, Sendable {
+    static let defaultFilter = LocationFilter.none
+    static let defaultNearbyDistanceThreshold: CLLocationDistance = 16093.44  // 10 miles
 
-  internal init(distanceThreshold: CLLocationDistance = 0, locationFilter: LocationFilter = .none) {
-    self.distanceThreshold = distanceThreshold
-    self.locationFilter = locationFilter
+    var distanceThreshold: CLLocationDistance
+    var locationFilter: LocationFilter
+
+    init(
+      distanceThreshold: CLLocationDistance = defaultNearbyDistanceThreshold,
+      locationFilter: LocationFilter = defaultFilter
+    ) {
+      self.distanceThreshold = distanceThreshold
+      self.locationFilter = locationFilter
+    }
+  }
+
+  private var state: State
+
+  internal init(_ state: State = State()) {
+    self.state = state
+  }
+
+  var distanceThreshold: CLLocationDistance {
+    get {
+      state.distanceThreshold
+    }
+    set {
+      state.distanceThreshold = newValue
+    }
+  }
+
+  var locationFilter: LocationFilter {
+    get {
+      state.locationFilter
+    }
+    set {
+      state.locationFilter = newValue
+    }
+  }
+}
+
+extension NearbyModel: RawRepresentable {
+  convenience init?(rawValue: String) {
+    Logger.nearby.log("loading: \(rawValue, privacy: .public)")
+    guard let data = rawValue.data(using: .utf8) else { return nil }
+    guard let state = try? JSONDecoder().decode(State.self, from: data) else { return nil }
+    self.init(state)
+  }
+
+  var rawValue: String {
+    guard let data = try? JSONEncoder().encode(state) else { return "" }
+    guard let value = String(data: data, encoding: .utf8) else { return "" }
+    Logger.nearby.log("saving: \(value, privacy: .public)")
+    return value
   }
 }

--- a/Sources/Site/Music/UI/ArchiveStateView.swift
+++ b/Sources/Site/Music/UI/ArchiveStateView.swift
@@ -18,8 +18,7 @@ struct ArchiveStateView: View {
   @SceneStorage("venue.sort") private var venueSort = RankingSort.alphabetical
   @SceneStorage("artist.sort") private var artistSort = RankingSort.alphabetical
   @SceneStorage("navigation.state") private var archiveNavigation = ArchiveNavigation()
-
-  @State private var nearbyModel: NearbyModel = NearbyModel()
+  @SceneStorage("nearby.state") private var nearbyModel = NearbyModel()
 
   @ViewBuilder private var archiveBody: some View {
     ArchiveCategorySplit(

--- a/Sources/Site/Music/UI/LocationFilterModifier.swift
+++ b/Sources/Site/Music/UI/LocationFilterModifier.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 struct LocationFilterModifier: ViewModifier {
-  @SceneStorage("nearby.filter") private var locationFilter = LocationFilter.none
-
   let model: NearbyModel
   let locationAuthorization: LocationAuthorization
   let geocodingProgress: Double
@@ -26,12 +24,6 @@ struct LocationFilterModifier: ViewModifier {
       content
     }
     .toolbar { LocationFilterToolbarContent(isOn: $bindableModel.locationFilter.toggle) }
-    .task {
-      model.locationFilter = locationFilter
-    }
-    .onChange(of: model.locationFilter) { _, newValue in
-      locationFilter = newValue
-    }
   }
 }
 

--- a/Sources/Site/Music/UI/NearbyDistanceThresholdModifier.swift
+++ b/Sources/Site/Music/UI/NearbyDistanceThresholdModifier.swift
@@ -9,9 +9,6 @@ import CoreLocation
 import SwiftUI
 
 struct NearbyDistanceThresholdModifier: ViewModifier {
-  @SceneStorage("nearby.distance") private var nearbyDistanceThreshold: CLLocationDistance =
-    16093.44  // 10 miles
-
   let model: NearbyModel
 
   func body(content: Content) -> some View {
@@ -19,12 +16,6 @@ struct NearbyDistanceThresholdModifier: ViewModifier {
       #if !os(tvOS)
         .toolbar { NearbyDistanceThresholdToolbarContent(model: model) }
       #endif
-      .task {
-        model.distanceThreshold = nearbyDistanceThreshold
-      }
-      .onChange(of: model.distanceThreshold) { _, newValue in
-        nearbyDistanceThreshold = newValue
-      }
   }
 }
 


### PR DESCRIPTION
- This way NearbyModel's State is persisted via @SceneStorage. It removes persisting code from the various modifiers for this state.
- Insprired by the work done for ArchiveNavigation in #845