### PR TITLE
abstract away searchable content description

### DIFF
--- a/Sources/Site/Music/AnnumDigest+NSUserActivity.swift
+++ b/Sources/Site/Music/AnnumDigest+NSUserActivity.swift
@@ -5,7 +5,6 @@
 //  Created by Greg Bolsinga on 6/21/23.
 //
 
-import CoreSpotlight
 import Foundation
 
 extension AnnumDigest: PathRestorableUserActivity {
@@ -14,10 +13,7 @@ extension AnnumDigest: PathRestorableUserActivity {
 
     userActivity.isEligibleForSearch = true
     userActivity.title = self.annum.formatted()
-    #if !os(tvOS)
-      let attributes = CSSearchableItemAttributeSet(contentType: .content)
-      attributes.contentDescription = String(localized: "See Shows From This Year", bundle: .module)
-      userActivity.contentAttributeSet = attributes
-    #endif
+    userActivity.addSearchableContent(
+      description: String(localized: "See Shows From This Year", bundle: .module))
   }
 }

--- a/Sources/Site/Music/ArtistDigest+NSUserActivity.swift
+++ b/Sources/Site/Music/ArtistDigest+NSUserActivity.swift
@@ -5,7 +5,6 @@
 //  Created by Greg Bolsinga on 6/21/23.
 //
 
-import CoreSpotlight
 import Foundation
 
 extension ArtistDigest: PathRestorableUserActivity {
@@ -14,11 +13,7 @@ extension ArtistDigest: PathRestorableUserActivity {
 
     userActivity.isEligibleForSearch = true
     userActivity.title = self.name
-    #if !os(tvOS)
-      let attributes = CSSearchableItemAttributeSet(contentType: .content)
-      attributes.contentDescription = String(
-        localized: "See Shows With This Artist", bundle: .module)
-      userActivity.contentAttributeSet = attributes
-    #endif
+    userActivity.addSearchableContent(
+      description: String(localized: "See Shows With This Artist", bundle: .module))
   }
 }

--- a/Sources/Site/Music/Concert+NSUserActivity.swift
+++ b/Sources/Site/Music/Concert+NSUserActivity.swift
@@ -5,7 +5,6 @@
 //  Created by Greg Bolsinga on 6/21/23.
 //
 
-import CoreSpotlight
 import Foundation
 
 extension Concert: PathRestorableUserActivity {
@@ -14,10 +13,7 @@ extension Concert: PathRestorableUserActivity {
 
     userActivity.isEligibleForSearch = true
     userActivity.title = self.formatted(.headlinerAndVenue)
-    #if !os(tvOS)
-      let attributes = CSSearchableItemAttributeSet(contentType: .content)
-      attributes.contentDescription = String(localized: "See More About This Show", bundle: .module)
-      userActivity.contentAttributeSet = attributes
-    #endif
+    userActivity.addSearchableContent(
+      description: String(localized: "See More About This Show", bundle: .module))
   }
 }

--- a/Sources/Site/Music/NSUserActivity+Search.swift
+++ b/Sources/Site/Music/NSUserActivity+Search.swift
@@ -1,0 +1,19 @@
+//
+//  NSUserActivity+Search.swift
+//  site
+//
+//  Created by Greg Bolsinga on 10/11/24.
+//
+
+import CoreSpotlight
+import Foundation
+
+extension NSUserActivity {
+  func addSearchableContent(description: String) {
+    #if !os(tvOS)
+      let attributes = CSSearchableItemAttributeSet(contentType: .content)
+      attributes.contentDescription = description
+      self.contentAttributeSet = attributes
+    #endif
+  }
+}

--- a/Sources/Site/Music/VenueDigest+NSUserActivity.swift
+++ b/Sources/Site/Music/VenueDigest+NSUserActivity.swift
@@ -5,7 +5,6 @@
 //  Created by Greg Bolsinga on 6/21/23.
 //
 
-import CoreSpotlight
 import Foundation
 
 extension VenueDigest: PathRestorableUserActivity {
@@ -14,10 +13,7 @@ extension VenueDigest: PathRestorableUserActivity {
 
     userActivity.isEligibleForSearch = true
     userActivity.title = self.name
-    #if !os(tvOS)
-      let attributes = CSSearchableItemAttributeSet(contentType: .content)
-      attributes.contentDescription = String(localized: "See Shows At This Venue", bundle: .module)
-      userActivity.contentAttributeSet = attributes
-    #endif
+    userActivity.addSearchableContent(
+      description: String(localized: "See Shows At This Venue", bundle: .module))
   }
 }


### PR DESCRIPTION
Hide CoreSpotlight stuff that doesn't support tvOS in an extension to reduce OS checks at compile time.