### PR TITLE
Separate ArchiveNavigation/NearbyModel.State json String from description and RawRepresentable

### DIFF
--- a/Sources/Site/Music/NearbyModel.swift
+++ b/Sources/Site/Music/NearbyModel.swift
@@ -28,6 +28,21 @@ extension Logger {
       self.distanceThreshold = distanceThreshold
       self.locationFilter = locationFilter
     }
+
+    internal init?(jsonString: String) {
+      guard let data = jsonString.data(using: .utf8),
+        let state = try? JSONDecoder().decode(State.self, from: data)
+      else { return nil }
+      self = state
+    }
+
+    var jsonString: String {
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = [.sortedKeys]
+      guard let data = try? encoder.encode(self), let value = String(data: data, encoding: .utf8)
+      else { return "" }
+      return value
+    }
   }
 
   private var state: State
@@ -58,14 +73,12 @@ extension Logger {
 extension NearbyModel: RawRepresentable {
   convenience init?(rawValue: String) {
     Logger.nearby.log("loading: \(rawValue, privacy: .public)")
-    guard let data = rawValue.data(using: .utf8) else { return nil }
-    guard let state = try? JSONDecoder().decode(State.self, from: data) else { return nil }
+    guard let state = State(jsonString: rawValue) else { return nil }
     self.init(state)
   }
 
   var rawValue: String {
-    guard let data = try? JSONEncoder().encode(state) else { return "" }
-    guard let value = String(data: data, encoding: .utf8) else { return "" }
+    let value = state.jsonString
     Logger.nearby.log("saving: \(value, privacy: .public)")
     return value
   }


### PR DESCRIPTION
This allows the json string to be used for the CustomStringConvertible. However can't make State RawRepresentable for a String, since State is also Codable, and if it is RawRepresentable, there will be an infinite loop.

This is basically getting rid of a "saving" archive log when that isn't what was happening. Just save that for the RawRepresentable stubs, and allow with logs to access the JSON directly.