### PR TITLE
Locations are no longer AtlasGeocodable

### DIFF
--- a/Sources/Site/Music/Location+Geocode.swift
+++ b/Sources/Site/Music/Location+Geocode.swift
@@ -12,7 +12,7 @@ import Foundation
   import Contacts
 #endif
 
-extension Location: AtlasGeocodable {
+extension Location {
   #if canImport(Contacts)
     private var postalAddress: CNPostalAddress {
       let pAddress = CNMutablePostalAddress()


### PR DESCRIPTION
They do not need to be. In the newer geocoding code in OS 26, more informaton from Venue may be passed, so Location will have some, but not all of the data that would be useful for Geocoding.