### PR TITLE
Atlas no longer depends upon CLPlacemark

### DIFF
--- a/Sources/Site/Music/Atlas.swift
+++ b/Sources/Site/Music/Atlas.swift
@@ -14,10 +14,12 @@ extension Logger {
 }
 
 protocol Geocodable {
-  func geocode() async throws -> CLPlacemark
+  associatedtype Place
+  func geocode() async throws -> Place
 }
 
-protocol AtlasGeocodable: Geocodable, Codable, Equatable, Hashable, Sendable {}
+protocol AtlasGeocodable: Geocodable, Codable, Equatable, Hashable, Sendable
+where Place: Codable & Sendable {}
 
 private enum Constants {
   static let maxRequests = 50
@@ -42,7 +44,7 @@ actor Atlas<T: AtlasGeocodable> {
     reset()
   }
 
-  public func geocode(_ geocodable: T) async throws -> CLPlacemark {
+  public func geocode(_ geocodable: T) async throws -> T.Place {
     if let result = await cache.get(geocodable) {
       Logger.atlas.log("cached result")
       return result
@@ -53,7 +55,7 @@ actor Atlas<T: AtlasGeocodable> {
     return result
   }
 
-  private func gatedGeocode(_ geocodable: T) async throws -> CLPlacemark {
+  private func gatedGeocode(_ geocodable: T) async throws -> T.Place {
     Logger.atlas.log("start gatedGeocode")
     defer {
       Logger.atlas.log("end gatedGeocode")

--- a/Sources/Site/Music/AtlasCache.swift
+++ b/Sources/Site/Music/AtlasCache.swift
@@ -5,7 +5,6 @@
 //  Created by Greg Bolsinga on 9/22/23.
 //
 
-import CoreLocation
 import Foundation
 import os
 
@@ -16,10 +15,9 @@ extension Logger {
 private let expirationOffset = 60.0 * 60.0 * 24.0 * 30.0 * 6.0  // Six months
 private let ExpirationStaggerDuration = 60.0 * 60.0 * 6.0  // Quarter day
 
-actor AtlasCache<T: AtlasGeocodable> {
+actor AtlasCache<T: AtlasGeocodable> where T.Place: Sendable {
   struct Value: Codable {
-    @NSCodingCodable
-    var placemark: CLPlacemark
+    var placemark: T.Place
     let expirationDate: Date
   }
 
@@ -46,11 +44,11 @@ actor AtlasCache<T: AtlasGeocodable> {
     }
   }
 
-  func get(_ item: T) -> CLPlacemark? { self[item] }
+  func get(_ item: T) -> T.Place? { self[item] }
 
-  func add(_ item: T, value: CLPlacemark) { self[item] = value }
+  func add(_ item: T, value: T.Place) { self[item] = value }
 
-  private subscript(index: T) -> CLPlacemark? {
+  private subscript(index: T) -> T.Place? {
     get {
       cache[index]?.placemark
     }

--- a/Sources/Site/Music/AtlasCache.swift
+++ b/Sources/Site/Music/AtlasCache.swift
@@ -15,7 +15,7 @@ extension Logger {
 private let expirationOffset = 60.0 * 60.0 * 24.0 * 30.0 * 6.0  // Six months
 private let ExpirationStaggerDuration = 60.0 * 60.0 * 6.0  // Quarter day
 
-actor AtlasCache<T: AtlasGeocodable> where T.Place: Sendable {
+actor AtlasCache<T: AtlasGeocodable> {
   struct Value: Codable {
     var placemark: T.Place
     let expirationDate: Date

--- a/Sources/Site/Music/BatchGeocode.swift
+++ b/Sources/Site/Music/BatchGeocode.swift
@@ -5,11 +5,10 @@
 //  Created by Greg Bolsinga on 5/3/23.
 //
 
-import CoreLocation
 import Foundation
 
 struct BatchGeocode<T: AtlasGeocodable>: AsyncSequence {
-  typealias Element = (T, CLPlacemark)
+  typealias Element = (T, T.Place)
 
   let atlas: Atlas<T>
   let geocodables: [T]

--- a/Sources/Site/Music/Geocode.swift
+++ b/Sources/Site/Music/Geocode.swift
@@ -11,20 +11,20 @@ private enum GeocodeError: Error {
   case noPlacemark
 }
 
-func geocodeAddressString(_ addressString: String) async throws -> CLPlacemark {
+func geocodeAddressString(_ addressString: String) async throws -> Placemark {
   guard let placemark = try await CLGeocoder().geocodeAddressString(addressString).first else {
     throw GeocodeError.noPlacemark
   }
-  return placemark
+  return Placemark(placemark: placemark)
 }
 
 #if canImport(Contacts)
   import Contacts
 
-  func geocodePostalAddress(_ address: CNPostalAddress) async throws -> CLPlacemark {
+  func geocodePostalAddress(_ address: CNPostalAddress) async throws -> Placemark {
     guard let placemark = try await CLGeocoder().geocodePostalAddress(address).first else {
       throw GeocodeError.noPlacemark
     }
-    return placemark
+    return Placemark(placemark: placemark)
   }
 #endif

--- a/Sources/Site/Music/Location+Geocode.swift
+++ b/Sources/Site/Music/Location+Geocode.swift
@@ -38,7 +38,7 @@ extension Location {
     }
   #endif
 
-  public func geocode() async throws -> CLPlacemark {
+  func geocode() async throws -> Placemark {
     #if canImport(Contacts)
       try await geocodePostalAddress(self.postalAddress)
     #else

--- a/Sources/Site/Music/Placemark.swift
+++ b/Sources/Site/Music/Placemark.swift
@@ -1,0 +1,19 @@
+//
+//  Placemark.swift
+//  site
+//
+//  Created by Greg Bolsinga on 6/10/25.
+//
+
+import CoreLocation
+
+struct Placemark: Codable, Sendable {
+  @NSCodingCodable
+  var placemark: CLPlacemark
+}
+
+extension Placemark {
+  func nearby(to otherLocation: CLLocation, distanceThreshold: CLLocationDistance) -> Bool {
+    placemark.nearby(to: otherLocation, distanceThreshold: distanceThreshold)
+  }
+}

--- a/Sources/Site/Music/UI/VenueDetail.swift
+++ b/Sources/Site/Music/UI/VenueDetail.swift
@@ -5,12 +5,11 @@
 //  Created by Greg Bolsinga on 2/16/23.
 //
 
-import CoreLocation
 import MapKit
 import SwiftUI
 
 struct VenueDetail: View {
-  typealias geocoder = (VenueDigest) async throws -> CLPlacemark
+  typealias geocoder = (VenueDigest) async throws -> Placemark
 
   let digest: VenueDigest
   let concertCompare: (Concert, Concert) -> Bool
@@ -35,7 +34,7 @@ struct VenueDetail: View {
         .task(id: digest) {
           guard let geocode else { return }
           do {
-            item = MKMapItem(placemark: MKPlacemark(placemark: try await geocode(digest)))
+            item = MKMapItem(placemark: MKPlacemark(placemark: try await geocode(digest).placemark))
           } catch {}
         }
         #if !os(tvOS)

--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -23,7 +23,7 @@ enum LocationAuthorization {
   public let vault: Vault
 
   internal var todayConcerts: [Concert] = []
-  private var venuePlacemarks: [Venue.ID: CLPlacemark] = [:]
+  private var venuePlacemarks: [Venue.ID: Placemark] = [:]
   private var currentLocation: CLLocation?
   internal var locationAuthorization = LocationAuthorization.allowed
 

--- a/Sources/Site/Music/Venue+Geocodable.swift
+++ b/Sources/Site/Music/Venue+Geocodable.swift
@@ -9,7 +9,7 @@ import CoreLocation
 import Foundation
 
 extension Venue: AtlasGeocodable {
-  func geocode() async throws -> CLPlacemark {
+  func geocode() async throws -> Placemark {
     try await location.geocode()
   }
 }

--- a/Sources/Site/Utility/NSCodingCodable.swift
+++ b/Sources/Site/Utility/NSCodingCodable.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @propertyWrapper
-struct NSCodingCodable<T: NSObject & NSCoding>: Codable {
+struct NSCodingCodable<T: NSObject & NSCoding & Sendable>: Codable {
   enum NSCodingCodableError: Error {
     case decodeFailure
   }

--- a/Sources/Site/Utility/Placemark+Geometry.swift
+++ b/Sources/Site/Utility/Placemark+Geometry.swift
@@ -17,7 +17,7 @@ extension CLPlacemark {
     return circularRegion.radius
   }
 
-  func distance(from otherLocation: CLLocation) -> CLLocationDistance {
+  private func distance(from otherLocation: CLLocation) -> CLLocationDistance {
     guard let location else { return CLLocationDistanceMax }
     return location.distance(from: otherLocation)
   }


### PR DESCRIPTION
This is because in OS 26 there is better functionality for geocoding in MapKit.