### PR TITLE
RankingList.rankSorted is non-Optional

### DIFF
--- a/Sources/Site/Music/UI/RankableSortList.swift
+++ b/Sources/Site/Music/UI/RankableSortList.swift
@@ -26,7 +26,7 @@ where T: Rankable, T.ID == String {
     if sort.isAlphabetical {
       RankingList(
         items: items,
-        rankingMapBuilder: { sectioner.sectionMap(for: $0) },
+        rankingMapBuilder: { sectioner.sectionMap(for: $0) }, rankSorted: <,
         itemContentView: { showCount(for: $0) },
         sectionHeaderView: { $0.representingView }, itemLabelView: itemLabelView)
     } else if sort.isFirstSeen {
@@ -39,7 +39,7 @@ where T: Rankable, T.ID == String {
     } else {
       RankingList(
         items: items,
-        rankingMapBuilder: { $0.ranked(by: sort) },
+        rankingMapBuilder: { $0.ranked(by: sort) }, rankSorted: <,
         itemContentView: { if sort.isShowYearRange { showCount(for: $0) } },
         sectionHeaderView: {
           switch sort {

--- a/Sources/Site/Music/UI/RankingList.swift
+++ b/Sources/Site/Music/UI/RankingList.swift
@@ -11,7 +11,7 @@ struct RankingList<T, R, ItemContent: View, SectionHeader: View, LabelContent: V
 where T: LibraryComparable, T: Hashable, T: PathRestorable, R: Comparable, R: Hashable {
   let items: [T]
   let rankingMapBuilder: ([T]) -> [R: [T]]
-  var rankSorted: ((R, R) -> Bool)?
+  var rankSorted: ((R, R) -> Bool)
   @ViewBuilder let itemContentView: (T) -> ItemContent
   @ViewBuilder let sectionHeaderView: (R) -> SectionHeader
   @ViewBuilder let itemLabelView: ((T) -> LabelContent)
@@ -19,7 +19,7 @@ where T: LibraryComparable, T: Hashable, T: PathRestorable, R: Comparable, R: Ha
   var body: some View {
     let rankingMap = rankingMapBuilder(items)
     List {
-      ForEach(rankingMap.keys.sorted(by: rankSorted ?? (<)), id: \.self) { ranking in
+      ForEach(rankingMap.keys.sorted(by: rankSorted), id: \.self) { ranking in
         if let items = rankingMap[ranking] {
           Section {
             ForEach(items) { item in
@@ -63,7 +63,7 @@ where T: LibraryComparable, T: Hashable, T: PathRestorable, R: Comparable, R: Ha
     items: vaultPreviewData.venueDigests,
     rankingMapBuilder: { artists in
       return [Ranking(rank: .rank(1), value: 3): artists]
-    },
+    }, rankSorted: <,
     itemContentView: { _ in },
     sectionHeaderView: { section in
       Text("Venues")


### PR DESCRIPTION
When building with Xcode 26 Beta it fixes the following warning:

```
22 |       ForEach(rankingMap.keys.sorted(by: rankSorted ?? (<)), id: \.self) { ranking in
   |                                                         |- error: sending '$base$' risks causing data races [#SendingRisksDataRace]
   |                                                         `- note: task-isolated '$base$' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses
```

See https://github.com/bolsinga/site/actions/runs/15714862525/job/44281967115#step:6:249