### PR TITLE
use a specific version of PackageBuildInfo instead of a branch

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
-    .package(url: "https://github.com/bolsinga/PackageBuildInfo", branch: "main"),
+    .package(url: "https://github.com/bolsinga/PackageBuildInfo", exact: "2.0.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Fixes https://github.com/bolsinga/SiteApp/actions/runs/16127044067/job/45506356264 :

```
  Failed to resolve dependencies Dependencies could not be resolved because package 'site' is required using a stable-version but 'site' depends on an unstable-version package 'packagebuildinfo' and root depends on 'site' 1.0.11.
```