### PR TITLE
When externally navigating to a path, set the category

### DIFF
--- a/Sources/Site/Music/UI/ArchivePath+ArchiveCategory.swift
+++ b/Sources/Site/Music/UI/ArchivePath+ArchiveCategory.swift
@@ -8,20 +8,14 @@
 import Foundation
 
 extension ArchivePath {
-  enum CategoryError: Error {
-    case invalidCategory
-  }
-
-  func category() throws -> ArchiveCategory {
+  var category: ArchiveCategory {
     switch self {
-    case .show(_):
+    case .show(_), .year(_):
       return .shows
     case .venue(_):
       return .venues
     case .artist(_):
       return .artists
-    case .year(_):
-      throw CategoryError.invalidCategory
     }
   }
 }

--- a/Tests/SiteTests/ArchiveNavigationTests.swift
+++ b/Tests/SiteTests/ArchiveNavigationTests.swift
@@ -53,6 +53,18 @@ extension ArchiveNavigation.State {
   }
 }
 
+extension ArchiveNavigation {
+  convenience init(category: ArchiveCategory?, categoryPaths: [ArchiveCategory: [ArchivePath]]) {
+    self.init(
+      ArchiveNavigation.State(category: category, categoryPaths: categoryPaths),
+      useDispatchMainWorkaround: false)
+  }
+
+  convenience init() {
+    self.init(useDispatchMainWorkaround: false)
+  }
+}
+
 let regularActivities = ArchiveCategory.allCases.filter { $0.isRegularActivity }
 let irregularActivities = ArchiveCategory.allCases.filter { !$0.isRegularActivity }
 
@@ -91,9 +103,7 @@ struct ArchiveNavigationTests {
 
   @Test func navigateToCategory_existingPath() {
     let ar = ArchiveNavigation(
-      ArchiveNavigation.State(
-        category: .artists, categoryPaths: [.artists: [Artist(id: "id", name: "name").archivePath]])
-    )
+      category: .artists, categoryPaths: [.artists: [Artist(id: "id", name: "name").archivePath]])
     #expect(ar.category != nil)
     #expect(ar.category == .artists)
     #expect(!ar.path.isEmpty)
@@ -118,29 +128,29 @@ struct ArchiveNavigationTests {
 
     ar.navigate(to: ArchivePath.artist("id"))
     #expect(ar.category != nil)
-    #expect(ar.category == .defaultCategory)
+    #expect(ar.category == .artists)
     #expect(ar.path.count == 1)
     #expect(ar.path.last != nil)
     #expect(ar.path.last! == ArchivePath.artist("id"))
 
     ar.navigate(to: ArchivePath.venue("id"))
     #expect(ar.category != nil)
-    #expect(ar.category == .defaultCategory)
-    #expect(ar.path.count == 2)
+    #expect(ar.category == .venues)
+    #expect(ar.path.count == 1)
     #expect(ar.path.last != nil)
     #expect(ar.path.last! == ArchivePath.venue("id"))
 
     ar.navigate(to: ArchivePath.show("id"))
     #expect(ar.category != nil)
-    #expect(ar.category == .defaultCategory)
-    #expect(ar.path.count == 3)
+    #expect(ar.category == .shows)
+    #expect(ar.path.count == 1)
     #expect(ar.path.last != nil)
     #expect(ar.path.last! == ArchivePath.show("id"))
 
     ar.navigate(to: ArchivePath.year(Annum.year(1989)))
     #expect(ar.category != nil)
-    #expect(ar.category == .defaultCategory)
-    #expect(ar.path.count == 4)
+    #expect(ar.category == .shows)
+    #expect(ar.path.count == 1)
     #expect(ar.path.last != nil)
     #expect(ar.path.last! == ArchivePath.year(Annum.year(1989)))
   }
@@ -150,29 +160,27 @@ struct ArchiveNavigationTests {
     ar.navigate(to: ArchivePath.artist("id"))
     #expect(ar.path.count == 1)
     #expect(ar.path.first! == ArchivePath.artist("id"))
-    #expect(ar.category == .defaultCategory)
+    #expect(ar.category == .artists)
 
     ar.navigate(to: ArchivePath.artist("id"))
     #expect(ar.path.count == 1)
     #expect(ar.path.first! == ArchivePath.artist("id"))
-    #expect(ar.category == .defaultCategory)
+    #expect(ar.category == .artists)
 
     ar.navigate(to: ArchivePath.artist("id-1"))
-    #expect(ar.path.count == 2)
-    #expect(ar.path.first! == ArchivePath.artist("id"))
-    #expect(ar.path.last! == ArchivePath.artist("id-1"))
-    #expect(ar.category == .defaultCategory)
+    #expect(ar.path.count == 1)
+    #expect(ar.path.first! == ArchivePath.artist("id-1"))
+    #expect(ar.category == .artists)
 
     ar.navigate(to: ArchivePath.venue("vid-1"))
-    #expect(ar.path.count == 3)
-    #expect(ar.path.first! == ArchivePath.artist("id"))
-    #expect(ar.path.last! == ArchivePath.venue("vid-1"))
-    #expect(ar.category == .defaultCategory)
+    #expect(ar.path.count == 1)
+    #expect(ar.path.first! == ArchivePath.venue("vid-1"))
+    #expect(ar.category == .venues)
   }
 
   @Test("Activity - nil")
   func activityNone() throws {
-    let ar = ArchiveNavigation(ArchiveNavigation.State(category: nil, categoryPaths: [:]))
+    let ar = ArchiveNavigation(category: nil, categoryPaths: [:])
     let activity = ar.activity
 
     #expect(activity.isNone)
@@ -195,8 +203,7 @@ struct ArchiveNavigationTests {
 
   @Test("Activity", arguments: regularActivities, [[], [ArchivePath.artist("id")]])
   func activity(category: ArchiveCategory, path: [ArchivePath]) {
-    let ar = ArchiveNavigation(
-      ArchiveNavigation.State(category: category, categoryPaths: [category: path]))
+    let ar = ArchiveNavigation(category: category, categoryPaths: [category: path])
     let activity = ar.activity
 
     #expect(!activity.isNone)
@@ -213,8 +220,7 @@ struct ArchiveNavigationTests {
 
   @Test("Activity - Irregular", arguments: irregularActivities, [[], [ArchivePath.artist("id")]])
   func activity_stats(category: ArchiveCategory, path: [ArchivePath]) {
-    let ar = ArchiveNavigation(
-      ArchiveNavigation.State(category: category, categoryPaths: [category: path]))
+    let ar = ArchiveNavigation(category: category, categoryPaths: [category: path])
     let activity = ar.activity
 
     #expect(!activity.isNone)

--- a/Tests/SiteTests/ArchivePathTests.swift
+++ b/Tests/SiteTests/ArchivePathTests.swift
@@ -141,10 +141,10 @@ struct ArchivePathTests {
   }
 
   @Test func archiveCategories() throws {
-    #expect(try ArchivePath.artist("blah").category() == ArchiveCategory.artists)
-    #expect(try ArchivePath.venue("blah").category() == ArchiveCategory.venues)
-    #expect(try ArchivePath.show("blah").category() == ArchiveCategory.shows)
-    #expect(throws: (any Error).self) { try ArchivePath.year(.year(1989)).category() }
-    #expect(throws: (any Error).self) { try ArchivePath.year(.unknown).category() }
+    #expect(ArchivePath.artist("blah").category == ArchiveCategory.artists)
+    #expect(ArchivePath.venue("blah").category == ArchiveCategory.venues)
+    #expect(ArchivePath.show("blah").category == ArchiveCategory.shows)
+    #expect(ArchivePath.year(.year(1989)).category == ArchiveCategory.shows)
+    #expect(ArchivePath.year(.unknown).category == ArchiveCategory.shows)
   }
 }


### PR DESCRIPTION
- This exposed an issue where changing both the category and path would *clear* the path.
- In an 1-1 SwiftUI lab WWDC25, this was the known workaround suggested by the team.
- Test URLs in a simulator with:
```
xcrun simctl openurl booted https://www.bolsinga.com/bands/ar1416.html
```
- Without this workaround, changing the category will update the UI such that the path is cleared after the first property changes.
- When both properties change, do not animate the first category property change  to eliminate a double animation.
- When both properties change, make the path change on the next turn of the RunLoop with an animation.
- **NOTE:** This use of DispatchQueue.main is the reason why this class is @MainActor. If this is removed in the future, remove the annotation from the class too.
