### PR TITLE
Raise Geocoded MKMapItem up, since it is the OS 26 geocoding result.

### DIFF
--- a/Sources/Site/Music/UI/ArchivePath+Destination.swift
+++ b/Sources/Site/Music/UI/ArchivePath+Destination.swift
@@ -5,6 +5,7 @@
 //  Created by Greg Bolsinga on 10/11/24.
 //
 
+import MapKit
 import SwiftUI
 
 extension ArchivePath {
@@ -21,7 +22,10 @@ extension ArchivePath {
       if let venueDigest = vault.venueDigestMap[iD] {
         VenueDetail(
           digest: venueDigest, concertCompare: vault.comparator.compare(lhs:rhs:),
-          geocode: { try await vault.atlas.geocode($0.venue) }, isPathNavigable: isPathNavigable
+          geocode: {
+            MKMapItem(
+              placemark: MKPlacemark(placemark: try await vault.atlas.geocode($0.venue).placemark))
+          }, isPathNavigable: isPathNavigable
         )
       }
     case .artist(let iD):

--- a/Sources/Site/Music/UI/VenueDetail.swift
+++ b/Sources/Site/Music/UI/VenueDetail.swift
@@ -5,11 +5,16 @@
 //  Created by Greg Bolsinga on 2/16/23.
 //
 
-import MapKit
 import SwiftUI
 
+#if swift(>=6.2)
+  import MapKit
+#else
+  @preconcurrency import MapKit
+#endif
+
 struct VenueDetail: View {
-  typealias geocoder = (VenueDigest) async throws -> Placemark
+  typealias geocoder = (VenueDigest) async throws -> MKMapItem
 
   let digest: VenueDigest
   let concertCompare: (Concert, Concert) -> Bool
@@ -34,7 +39,7 @@ struct VenueDetail: View {
         .task(id: digest) {
           guard let geocode else { return }
           do {
-            item = MKMapItem(placemark: MKPlacemark(placemark: try await geocode(digest).placemark))
+            item = try await geocode(digest)
           } catch {}
         }
         #if !os(tvOS)


### PR DESCRIPTION
- With Xcode 16.4 / non OS 26 / Swift 6.1,  MKMapItem is not Sendable, so it must be marked @preconcurrency.
- Shoe-horn in a conditional check for Swift 6.2 once we can go there. I think this should be conditional on the targetted SDK version, but I'm not sure how to do that at this level in the code.