### PR TITLE
Use Standard Settings for macOS

### DIFF
--- a/Sources/Site/Music/NearbyModel.swift
+++ b/Sources/Site/Music/NearbyModel.swift
@@ -1,0 +1,68 @@
+//
+//  NearbyModel.swift
+//
+//
+//  Created by Greg Bolsinga on 11/28/23.
+//
+
+import CoreLocation
+import Foundation
+import os
+
+extension Logger {
+  fileprivate static let nearby = Logger(category: "nearby")
+}
+
+@Observable final class NearbyModel {
+  struct State: Codable, Equatable, Sendable {
+    var locationFilter: LocationFilter
+
+    init(locationFilter: LocationFilter = .default) {
+      self.locationFilter = locationFilter
+    }
+
+    internal init?(jsonString: String) {
+      guard let data = jsonString.data(using: .utf8),
+        let state = try? JSONDecoder().decode(State.self, from: data)
+      else { return nil }
+      self = state
+    }
+
+    var jsonString: String {
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = [.sortedKeys]
+      guard let data = try? encoder.encode(self), let value = String(data: data, encoding: .utf8)
+      else { return "" }
+      return value
+    }
+  }
+
+  private var state: State
+
+  internal init(_ state: State = State()) {
+    self.state = state
+  }
+
+  var locationFilter: LocationFilter {
+    get {
+      state.locationFilter
+    }
+    set {
+      state.locationFilter = newValue
+    }
+  }
+}
+
+extension NearbyModel: RawRepresentable {
+  convenience init?(rawValue: String) {
+    Logger.nearby.log("loading: \(rawValue, privacy: .public)")
+    guard let state = State(jsonString: rawValue) else { return nil }
+    self.init(state)
+  }
+
+  var rawValue: String {
+    let value = state.jsonString
+    Logger.nearby.log("saving: \(value, privacy: .public)")
+    return value
+  }
+}

--- a/Sources/Site/Music/UI/ArchiveCategoryRoot.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryRoot.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ArchiveCategoryRoot: View {
   @Environment(VaultModel.self) var model
-  @AppStorage("nearby.filter") private var nearbyFilter = LocationFilter.default
+  @Environment(NearbyModel.self) var nearbyModel
 
   let category: ArchiveCategory
   let statsDisplayArchiveCategoryCounts: Bool
@@ -40,7 +40,8 @@ struct ArchiveCategoryRoot: View {
     )
     .toolbar {
       if category.isLocationFilterable {
-        LocationFilterToolbarContent(isOn: $nearbyFilter.toggle)
+        @Bindable var bindableNearbyModel = nearbyModel
+        LocationFilterToolbarContent(isOn: $bindableNearbyModel.locationFilter.toggle)
       }
       if let sortableData = sortableData(category) {
         SortModifierToolbarContent(algorithm: sortableData.sort) {
@@ -67,22 +68,22 @@ extension ArchiveCategoryRoot {
   }
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   ArchiveCategoryRoot(withPreviewCategory: .today)
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   ArchiveCategoryRoot(withPreviewCategory: .stats)
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   ArchiveCategoryRoot(withPreviewCategory: .shows)
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   ArchiveCategoryRoot(withPreviewCategory: .venues)
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   ArchiveCategoryRoot(withPreviewCategory: .artists)
 }

--- a/Sources/Site/Music/UI/ArchiveCategoryStack.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryStack.swift
@@ -39,22 +39,22 @@ extension ArchiveCategoryStack {
   }
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   ArchiveCategoryStack(withPreviewCategory: .today)
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   ArchiveCategoryStack(withPreviewCategory: .stats)
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   ArchiveCategoryStack(withPreviewCategory: .shows)
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   ArchiveCategoryStack(withPreviewCategory: .venues)
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   ArchiveCategoryStack(withPreviewCategory: .artists)
 }

--- a/Sources/Site/Music/UI/ArchiveStateView.swift
+++ b/Sources/Site/Music/UI/ArchiveStateView.swift
@@ -13,6 +13,7 @@ struct ArchiveStateView: View {
   @SceneStorage("venue.sort") private var venueSort = RankingSort.alphabetical
   @SceneStorage("artist.sort") private var artistSort = RankingSort.alphabetical
   @SceneStorage("navigation.state") private var archiveNavigation = ArchiveNavigation()
+  @SceneStorage("nearby.state") private var nearbyModel = NearbyModel()
 
   @State private var activity = ArchiveActivity.category(.defaultCategory)
 
@@ -35,6 +36,7 @@ struct ArchiveStateView: View {
         }
       }
     )
+    .environment(nearbyModel)
   }
 
   var body: some View {

--- a/Sources/Site/Music/UI/ArchiveTabView.swift
+++ b/Sources/Site/Music/UI/ArchiveTabView.swift
@@ -62,7 +62,7 @@ struct ArchiveTabView: View {
   }
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   ArchiveTabView(
     venueSort: .constant(.alphabetical), artistSort: .constant(.alphabetical),
     selectedCategory: .constant(.today), pathForCategory: { _ in .constant([]) }

--- a/Sources/Site/Music/UI/ArtistsSummary.swift
+++ b/Sources/Site/Music/UI/ArtistsSummary.swift
@@ -9,15 +9,14 @@ import SwiftUI
 
 struct ArtistsSummary: View {
   @Environment(VaultModel.self) var model
+  @Environment(NearbyModel.self) var nearbyModel
   @AppStorage("nearby.distance") private var nearbyDistance = defaultNearbyDistanceThreshold
-  @AppStorage("nearby.filter") private var nearbyFilter = LocationFilter.default
 
   let sort: RankingSort
   @Binding var searchString: String
 
   var body: some View {
-    let artistDigests = model.filteredArtistDigests(
-      locationFilter: nearbyFilter, distanceThreshold: nearbyDistance)
+    let artistDigests = model.filteredArtistDigests(nearbyModel, distanceThreshold: nearbyDistance)
     ArtistList(
       artistDigests: artistDigests, sectioner: model.vault.sectioner, sort: sort,
       searchString: $searchString
@@ -26,6 +25,6 @@ struct ArtistsSummary: View {
   }
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   ArtistsSummary(sort: .alphabetical, searchString: .constant(""))
 }

--- a/Sources/Site/Music/UI/NearbyLocationModifier.swift
+++ b/Sources/Site/Music/UI/NearbyLocationModifier.swift
@@ -9,14 +9,14 @@ import SwiftUI
 
 struct NearbyLocationModifier: ViewModifier {
   @Environment(VaultModel.self) var model
-  @AppStorage("nearby.filter") private var nearbyFilter = LocationFilter.default
+  @Environment(NearbyModel.self) var nearbyModel
 
   let filteredDataIsEmpty: Bool
 
   func body(content: Content) -> some View {
     content
       .overlay {
-        if nearbyFilter.isNearby {
+        if nearbyModel.locationFilter.isNearby {
           NearbyLocationView(
             locationAuthorization: model.locationAuthorization,
             geocodingProgress: model.geocodingProgress, filteredDataIsEmpty: filteredDataIsEmpty)

--- a/Sources/Site/Music/UI/NearbyPreviewModifer.swift
+++ b/Sources/Site/Music/UI/NearbyPreviewModifer.swift
@@ -1,0 +1,19 @@
+//
+//  NearbyPreviewModifer.swift
+//  site
+//
+//  Created by Greg Bolsinga on 7/29/25.
+//
+
+import SwiftUI
+
+struct NearbyPreviewModifer: PreviewModifier {
+  static func makeSharedContext() async throws -> NearbyModel {
+    NearbyModel()
+  }
+
+  func body(content: Content, context: NearbyModel) -> some View {
+    content
+      .environment(context)
+  }
+}

--- a/Sources/Site/Music/UI/ShowsSummary.swift
+++ b/Sources/Site/Music/UI/ShowsSummary.swift
@@ -9,17 +9,16 @@ import SwiftUI
 
 struct ShowsSummary: View {
   @Environment(VaultModel.self) var model
+  @Environment(NearbyModel.self) var nearbyModel
   @AppStorage("nearby.distance") private var nearbyDistance = defaultNearbyDistanceThreshold
-  @AppStorage("nearby.filter") private var nearbyFilter = LocationFilter.default
 
   var body: some View {
-    let decadesMap = model.filteredDecadesMap(
-      locationFilter: nearbyFilter, distanceThreshold: nearbyDistance)
+    let decadesMap = model.filteredDecadesMap(nearbyModel, distanceThreshold: nearbyDistance)
     ShowYearList(decadesMap: decadesMap)
       .nearbyLocation(filteredDataIsEmpty: decadesMap.isEmpty)
   }
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   ShowsSummary()
 }

--- a/Sources/Site/Music/UI/VenuesSummary.swift
+++ b/Sources/Site/Music/UI/VenuesSummary.swift
@@ -9,15 +9,14 @@ import SwiftUI
 
 struct VenuesSummary: View {
   @Environment(VaultModel.self) var model
+  @Environment(NearbyModel.self) var nearbyModel
   @AppStorage("nearby.distance") private var nearbyDistance = defaultNearbyDistanceThreshold
-  @AppStorage("nearby.filter") private var nearbyFilter = LocationFilter.default
 
   let sort: RankingSort
   @Binding var searchString: String
 
   var body: some View {
-    let venueDigests = model.filteredVenueDigests(
-      locationFilter: nearbyFilter, distanceThreshold: nearbyDistance)
+    let venueDigests = model.filteredVenueDigests(nearbyModel, distanceThreshold: nearbyDistance)
     VenueList(
       venueDigests: venueDigests, sectioner: model.vault.sectioner, sort: sort,
       searchString: $searchString
@@ -26,6 +25,6 @@ struct VenuesSummary: View {
   }
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier())) {
+#Preview(traits: .modifier(NearbyPreviewModifer()), .modifier(VaultPreviewModifier())) {
   VenuesSummary(sort: .alphabetical, searchString: .constant(""))
 }

--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -208,21 +208,22 @@ enum LocationAuthorization {
       .sorted { vault.comparator.compare(lhs: $0, rhs: $1) }
   }
 
-  func filteredDecadesMap(locationFilter: LocationFilter, distanceThreshold: CLLocationDistance)
+  func filteredDecadesMap(_ nearbyModel: NearbyModel, distanceThreshold: CLLocationDistance)
     -> [Decade: [Annum: [Concert.ID]]]
   {
-    locationFilter.isNearby ? decadesMapsNearby(distanceThreshold) : vault.decadesMap
+    nearbyModel.locationFilter.isNearby ? decadesMapsNearby(distanceThreshold) : vault.decadesMap
   }
 
-  func filteredVenueDigests(locationFilter: LocationFilter, distanceThreshold: CLLocationDistance)
+  func filteredVenueDigests(_ nearbyModel: NearbyModel, distanceThreshold: CLLocationDistance)
     -> [VenueDigest]
   {
-    locationFilter.isNearby ? venueDigestsNearby(distanceThreshold) : vault.venueDigests
+    nearbyModel.locationFilter.isNearby ? venueDigestsNearby(distanceThreshold) : vault.venueDigests
   }
 
-  func filteredArtistDigests(locationFilter: LocationFilter, distanceThreshold: CLLocationDistance)
+  func filteredArtistDigests(_ nearbyModel: NearbyModel, distanceThreshold: CLLocationDistance)
     -> [ArtistDigest]
   {
-    locationFilter.isNearby ? artistDigestsNearby(distanceThreshold) : vault.artistDigests
+    nearbyModel.locationFilter.isNearby
+      ? artistDigestsNearby(distanceThreshold) : vault.artistDigests
   }
 }


### PR DESCRIPTION
- `SceneStorage` wasn't working -> Up in the App, the Window has the Scene, and the macOS Settings is a different Scene. Therefore SceneStorage seemd to be the incorrect scope.
- Decided to use `AppStorage` for this data. However it was not working to persist a Codable, String RawRepresentable as it was for SceneStorage.
- So the AppStorage default values are globals and all the reference points need to reference the AppStorage directly to share the data.
- Only the nearbyDistanceThreshold is changed by Settings, so it is the only one using AppStorage.
- macOS does not show Settings in its tabs; iPad, iPhone, and tvOS still do.