### PR TITLE
Location Distance Editing via Toolbar on iPhone

### DIFF
--- a/Sources/Site/Music/UI/ArchiveCategoryRoot.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryRoot.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct ArchiveCategoryRoot: View {
   @Environment(VaultModel.self) var model
-  @Environment(NearbyModel.self) var nearbyModel
 
   let category: ArchiveCategory
   let statsDisplayArchiveCategoryCounts: Bool
@@ -20,6 +19,8 @@ struct ArchiveCategoryRoot: View {
 
   @State private var artistSearchString: String = ""
   @State private var venueSearchString: String = ""
+
+  @State private var showNearbyDistanceSettings: Bool = false
 
   private func sortableData(_ category: ArchiveCategory) -> (
     sort: Binding<RankingSort>, associatedRankName: String
@@ -43,8 +44,7 @@ struct ArchiveCategoryRoot: View {
     .refreshable { await reloadModel() }
     .toolbar {
       if category.isLocationFilterable {
-        @Bindable var bindableNearbyModel = nearbyModel
-        LocationFilterToolbarContent(isOn: $bindableNearbyModel.locationFilter.toggle)
+        LocationFilterToolbarContent { showNearbyDistanceSettings = true }
       }
       if let sortableData = sortableData(category) {
         SortModifierToolbarContent(algorithm: sortableData.sort) {
@@ -59,6 +59,7 @@ struct ArchiveCategoryRoot: View {
       ArchiveSharableToolbarContent(
         item: ArchiveCategoryLinkable(vault: model.vault, category: category))
     }
+    .sheet(isPresented: $showNearbyDistanceSettings) { SettingsView() }
   }
 }
 

--- a/Sources/Site/Music/UI/ArchiveSettingsPlacement.swift
+++ b/Sources/Site/Music/UI/ArchiveSettingsPlacement.swift
@@ -1,0 +1,22 @@
+//
+//  ArchiveSettingsPlacement.swift
+//  site
+//
+//  Created by Greg Bolsinga on 8/5/25.
+//
+
+#if canImport(UIKit)
+  import UIKit
+
+  extension UIDevice {
+    var showSettingsInTabView: Bool {
+      // Ideally this could check if the TabView was able to show a sidebar.
+      userInterfaceIdiom != .phone
+    }
+  }
+
+  @MainActor
+  var showSettingsInTabView: Bool {
+    UIDevice.current.showSettingsInTabView
+  }
+#endif

--- a/Sources/Site/Music/UI/ArchiveTabView.swift
+++ b/Sources/Site/Music/UI/ArchiveTabView.swift
@@ -19,14 +19,20 @@ extension ArchiveCategory {
     }
   }
 
+  @MainActor
   fileprivate static var trailingTabs: [ArchiveCategory] {
     #if os(macOS)
       [.stats]
     #else
-      [.stats, .settings]
+      if showSettingsInTabView {
+        [.stats, .settings]
+      } else {
+        [.stats]
+      }
     #endif
   }
 
+  @MainActor
   fileprivate static var tagOrder: [ArchiveCategory] {
     allCases.filter {
       if case .stats = $0 { return false }

--- a/Sources/Site/Music/UI/LocationFilterToolbarContent.swift
+++ b/Sources/Site/Music/UI/LocationFilterToolbarContent.swift
@@ -9,18 +9,54 @@ import SwiftUI
 
 struct LocationFilterToolbarContent: ToolbarContent {
   let placement: ToolbarItemPlacement
-  @Binding var isOn: Bool
+  @Environment(NearbyModel.self) var nearbyModel
+  let editNearbyDistanceAction: @MainActor () -> Void
 
-  internal init(placement: ToolbarItemPlacement = .primaryAction, isOn: Binding<Bool>) {
+  internal init(
+    placement: ToolbarItemPlacement = .primaryAction,
+    editNearbyDistanceAction: @escaping @MainActor () -> Void
+  ) {
     self.placement = placement
-    self._isOn = isOn
+    self.editNearbyDistanceAction = editNearbyDistanceAction
+  }
+
+  @ViewBuilder private var nearbyToggle: some View {
+    @Bindable var bindableNearbyModel = nearbyModel
+    Toggle(
+      String(localized: "Filter Nearby", bundle: .module), systemImage: "location.circle",
+      isOn: $bindableNearbyModel.locationFilter.toggle)
+  }
+
+  @ViewBuilder private var nearbySettingsMenu: some View {
+    Menu {
+      Button {
+        editNearbyDistanceAction()
+      } label: {
+        Label(
+          String(localized: "Edit Nearby Distance", bundle: .module),
+          systemImage: ArchiveCategory.settings.systemImage)
+      }
+    } label: {
+      Label(
+        String(localized: "Filter Nearby", bundle: .module),
+        systemImage: nearbyModel.locationFilter.isNearby
+          ? "location.circle.fill" : "location.circle")
+    } primaryAction: {
+      nearbyModel.locationFilter.toggle.toggle()
+    }
   }
 
   var body: some ToolbarContent {
     ToolbarItem(placement: placement) {
-      Toggle(
-        String(localized: "Filter Nearby", bundle: .module), systemImage: "location.circle",
-        isOn: $isOn)
+      #if os(macOS)
+        nearbyToggle
+      #else
+        if showSettingsInTabView {
+          nearbyToggle
+        } else {
+          nearbySettingsMenu
+        }
+      #endif
     }
   }
 }

--- a/Sources/Site/Resources/Localizable.xcstrings
+++ b/Sources/Site/Resources/Localizable.xcstrings
@@ -173,6 +173,9 @@
     "Display Shows On This Date" : {
 
     },
+    "Edit Nearby Distance" : {
+
+    },
     "Filter Nearby" : {
 
     },


### PR DESCRIPTION
- iPhone nearby toggle is now a Menu. A quick tap will toggle, and a press for the menu will bring up an option to show the SettingsView
- just iPhone will not show settings in the TabView