### PR TITLE
Revert "Remove top level navigation titles now that there are Tabs (#1033)"

### DIFF
--- a/Sources/Site/Music/UI/ArtistList.swift
+++ b/Sources/Site/Music/UI/ArtistList.swift
@@ -17,6 +17,7 @@ struct ArtistList: View {
     let digests = artistDigests.names(filteredBy: searchString)
     RankableSortList(
       items: digests, sectioner: sectioner,
+      title: String(localized: "Artists", bundle: .module),
       associatedRankSectionHeader: { $0.venuesCountView },
       itemLabelView: { Text($0.name.emphasizedAttributed(matching: searchString)) }, sort: sort
     )

--- a/Sources/Site/Music/UI/RankableSortList.swift
+++ b/Sources/Site/Music/UI/RankableSortList.swift
@@ -11,6 +11,7 @@ struct RankableSortList<T, SectionHeaderContent: View, LabelContent: View>: View
 where T: Rankable, T.ID == String {
   let items: [T]
   let sectioner: LibrarySectioner
+  let title: String
   @ViewBuilder let associatedRankSectionHeader: (Ranking) -> SectionHeaderContent
   @ViewBuilder let itemLabelView: ((T) -> LabelContent)
 
@@ -53,6 +54,7 @@ where T: Rankable, T.ID == String {
 
   var body: some View {
     listElement
+      .navigationTitle(Text(title))
   }
 }
 
@@ -60,7 +62,7 @@ where T: Rankable, T.ID == String {
   @Previewable @Environment(VaultModel.self) var model
   RankableSortList(
     items: model.vault.venueDigests, sectioner: model.vault.sectioner,
-    associatedRankSectionHeader: { $0.artistsCountView },
+    title: "Venues", associatedRankSectionHeader: { $0.artistsCountView },
     itemLabelView: { Text($0.name) }, sort: .alphabetical
   )
 }

--- a/Sources/Site/Music/UI/ShowYearList.swift
+++ b/Sources/Site/Music/UI/ShowYearList.swift
@@ -29,6 +29,7 @@ struct ShowYearList: View {
       }
     }
     .listStyle(.plain)
+    .navigationTitle(Text("Show Years", bundle: .module))
   }
 }
 

--- a/Sources/Site/Music/UI/StatsSummary.swift
+++ b/Sources/Site/Music/UI/StatsSummary.swift
@@ -15,6 +15,7 @@ struct StatsSummary: View {
       StatsGrouping(
         concerts: model.vault.concerts, displayArchiveCategoryCounts: true)
     }
+    .navigationTitle(Text(ArchiveCategory.stats.localizedString))
   }
 }
 

--- a/Sources/Site/Music/UI/VenueList.swift
+++ b/Sources/Site/Music/UI/VenueList.swift
@@ -17,6 +17,7 @@ struct VenueList: View {
     let digests = venueDigests.names(filteredBy: searchString)
     RankableSortList(
       items: digests, sectioner: sectioner,
+      title: String(localized: "Venues", bundle: .module),
       associatedRankSectionHeader: { $0.artistsCountView },
       itemLabelView: { Text($0.name.emphasizedAttributed(matching: searchString)) }, sort: sort
     )

--- a/Sources/Site/Resources/Localizable.xcstrings
+++ b/Sources/Site/Resources/Localizable.xcstrings
@@ -266,6 +266,9 @@
     "Show Venues" : {
 
     },
+    "Show Years" : {
+
+    },
     "Shows" : {
 
     },


### PR DESCRIPTION
This reverts commit f748956a43cd96a737aa242b115e2c1c64bbb98f.

This looks like more built-in apps with Tabs.