### PR TITLE
ShowsMode breaks userActivity / restoration (iPhone only)

### DIFF
--- a/Sources/Site/Music/UI/ArchiveCategoryStack.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryStack.swift
@@ -11,6 +11,7 @@ struct ArchiveCategoryStack: View {
   @Environment(VaultModel.self) var model
 
   let category: ArchiveCategory
+  @Binding var showsMode: ShowsMode
   @Binding var path: [ArchivePath]
   @Binding var venueSort: RankingSort
   @Binding var artistSort: RankingSort
@@ -30,7 +31,7 @@ struct ArchiveCategoryStack: View {
       StatsSummary()
     case .shows:
       if combineTodayAndShowSummary {
-        DaysShowsSummary()
+        DaysShowsSummary(mode: $showsMode)
       } else {
         ShowsSummary()
       }
@@ -64,7 +65,8 @@ struct ArchiveCategoryStack: View {
 extension ArchiveCategoryStack {
   init(withPreviewCategory category: ArchiveCategory) {
     self.init(
-      category: category, path: .constant([]), venueSort: .constant(.alphabetical),
+      category: category, showsMode: .constant(.ordinal), path: .constant([]),
+      venueSort: .constant(.alphabetical),
       artistSort: .constant(.alphabetical), reloadModel: {})
   }
 }

--- a/Sources/Site/Music/UI/DaysShowsSummary.swift
+++ b/Sources/Site/Music/UI/DaysShowsSummary.swift
@@ -8,25 +8,11 @@
 import SwiftUI
 
 struct DaysShowsSummary: View {
-  private enum Mode: CaseIterable {
-    case ordinal
-    case grouped
-
-    var systemImage: String {
-      switch self {
-      case .ordinal:
-        "calendar"
-      case .grouped:
-        "list.bullet"
-      }
-    }
-  }
-
-  @State private var mode = Self.Mode.ordinal
+  @Binding var mode: ShowsMode
 
   var body: some View {
     Picker(selection: $mode) {
-      ForEach(Mode.allCases, id: \.self) {
+      ForEach(ShowsMode.allCases, id: \.self) {
         Image(systemName: $0.systemImage)
       }
     } label: {
@@ -42,6 +28,10 @@ struct DaysShowsSummary: View {
   }
 }
 
-#Preview(traits: .modifier(VaultPreviewModifier()), .modifier(NearbyPreviewModifer())) {
-  DaysShowsSummary()
+#Preview("Ordinal", traits: .modifier(VaultPreviewModifier()), .modifier(NearbyPreviewModifer())) {
+  DaysShowsSummary(mode: .constant(.ordinal))
+}
+
+#Preview("Grouped", traits: .modifier(VaultPreviewModifier()), .modifier(NearbyPreviewModifer())) {
+  DaysShowsSummary(mode: .constant(.grouped))
 }

--- a/Sources/Site/Music/UI/ShowsMode.swift
+++ b/Sources/Site/Music/UI/ShowsMode.swift
@@ -1,0 +1,25 @@
+//
+//  ShowsMode.swift
+//  site
+//
+//  Created by Greg Bolsinga on 8/7/25.
+//
+
+enum ShowsMode: CaseIterable {
+  /// Shows Today Only.
+  case ordinal
+
+  /// Shows listed and grouped by decade, year, and then date.
+  case grouped
+
+  static var `default`: Self { .ordinal }
+
+  var systemImage: String {
+    switch self {
+    case .ordinal:
+      "calendar"
+    case .grouped:
+      "list.bullet"
+    }
+  }
+}


### PR DESCRIPTION
- Make a private ArchiveTab enum. This tracks the Tab selection. 
- -- It knows its ArchiveCategory. Pass this along to the rest of the UI code. 
- -- It will change the ArchiveCategory @Binding so that the ArchiveStateView will share the proper category.
- Track the ShowsMode of the DaysShowsSummary in the ArchiveTabView. 
- -- When it changes, change the @Binding ArchiveCategory, but not the selected ArchiveTab.
- Also fixes the ArchiveNavigation save/restore in AppStorage.