### PR TITLE
Add ArchiveCategory.search

### DIFF
--- a/Sources/Site/Music/UI/ArchiveCategory+FormatStyle.swift
+++ b/Sources/Site/Music/UI/ArchiveCategory+FormatStyle.swift
@@ -40,7 +40,7 @@ extension ArchiveCategory.FormatStyle: Foundation.FormatStyle {
         return "/venues/stats.html"
       case .artists:
         return "/bands/stats.html"
-      case .settings:
+      case .settings, .search:
         return ""
       }
     }

--- a/Sources/Site/Music/UI/ArchiveCategory+LocationFilterable.swift
+++ b/Sources/Site/Music/UI/ArchiveCategory+LocationFilterable.swift
@@ -8,7 +8,7 @@
 extension ArchiveCategory {
   var isLocationFilterable: Bool {
     switch self {
-    case .today, .stats, .settings:
+    case .today, .stats, .settings, .search:
       false
     case .shows, .venues, .artists:
       true

--- a/Sources/Site/Music/UI/ArchiveCategory+URL.swift
+++ b/Sources/Site/Music/UI/ArchiveCategory+URL.swift
@@ -10,7 +10,7 @@ import Foundation
 extension ArchiveCategory {
   fileprivate var isURLSharable: Bool {
     switch self {
-    case .today, .stats, .settings:
+    case .today, .stats, .settings, .search:
       return false
     case .shows, .venues, .artists:
       return true

--- a/Sources/Site/Music/UI/ArchiveCategory.swift
+++ b/Sources/Site/Music/UI/ArchiveCategory.swift
@@ -14,6 +14,7 @@ public enum ArchiveCategory: String, CaseIterable, Codable, Sendable {
   case venues
   case artists
   case settings
+  case search
 
   static var defaultCategory: ArchiveCategory { .today }
 
@@ -31,6 +32,8 @@ public enum ArchiveCategory: String, CaseIterable, Codable, Sendable {
       return String(localized: "Artists", bundle: .module)
     case .settings:
       return String(localized: "Settings", bundle: .module)
+    case .search:
+      return String(localized: "Search", bundle: .module)
     }
   }
 
@@ -48,6 +51,8 @@ public enum ArchiveCategory: String, CaseIterable, Codable, Sendable {
       "music.mic"
     case .settings:
       "gear"
+    case .search:
+      "magnifyingglass"
     }
   }
 
@@ -69,6 +74,8 @@ public enum ArchiveCategory: String, CaseIterable, Codable, Sendable {
       return String(localized: "Show Artists", bundle: .module)
     case .settings:
       return String(localized: "Settings", bundle: .module)
+    case .search:
+      return localizedString
     }
   }
 }

--- a/Sources/Site/Music/UI/ArchiveCategoryStack.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryStack.swift
@@ -47,6 +47,8 @@ struct ArchiveCategoryStack: View {
       ArtistsSummary(sort: artistSort, searchString: $artistSearchString)
     case .settings:
       SettingsView()
+    case .search:
+      EmptyView()
     }
   }
 

--- a/Sources/Site/Music/UI/ArchiveCategoryToolbarContent.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryToolbarContent.swift
@@ -30,7 +30,7 @@ struct ArchiveCategoryToolbarContent: ToolbarContent {
     sort: Binding<RankingSort>, associatedRankName: String
   )? {
     switch category {
-    case .today, .stats, .shows, .settings:
+    case .today, .stats, .shows, .settings, .search:
       nil
     case .venues:
       ($venueSort, String(localized: "Sort By Artist Count", bundle: .module))

--- a/Sources/Site/Music/UI/ArchiveNavigation.swift
+++ b/Sources/Site/Music/UI/ArchiveNavigation.swift
@@ -53,7 +53,7 @@ extension Logger {
       switch category {
       case .today:
         self.init(category: category, todayPath: [path])
-      case .stats, .settings:
+      case .stats, .settings, .search:
         self.init(category: category)
       case .shows:
         self.init(category: category, showsPath: [path])
@@ -111,7 +111,7 @@ extension Logger {
       switch category {
       case .today:
         return state.todayPath
-      case .stats, .settings:
+      case .stats, .settings, .search:
         return []
       case .shows:
         return state.showsPath
@@ -125,7 +125,7 @@ extension Logger {
       switch category {
       case .today:
         state.todayPath = newValue
-      case .stats, .settings:
+      case .stats, .settings, .search:
         break
       case .shows:
         state.showsPath = newValue

--- a/Sources/Site/Music/UI/ArchiveStateView.swift
+++ b/Sources/Site/Music/UI/ArchiveStateView.swift
@@ -27,7 +27,7 @@ struct ArchiveStateView: View {
         switch $0 {
         case .today:
           return $archiveNavigation.state.todayPath
-        case .stats, .settings:
+        case .stats, .settings, .search:
           return .constant([])
         case .shows:
           return $archiveNavigation.state.showsPath

--- a/Sources/Site/Music/UI/ArchiveTabView.swift
+++ b/Sources/Site/Music/UI/ArchiveTabView.swift
@@ -21,7 +21,7 @@ extension ArchiveCategory {
       } else {
         return nil
       }
-    case .stats, .venues, .artists, .settings:
+    case .stats, .venues, .artists, .settings, .search:
       return nil
     }
   }
@@ -79,6 +79,8 @@ extension ArchiveCategory {
       .artists
     case .settings:
       .settings
+    case .search:
+      .settings  // TODO: Add the search tab.
     }
   }
 }
@@ -118,7 +120,7 @@ struct ArchiveTabView: View {
         showsMode = .ordinal
       case .shows:
         showsMode = .grouped
-      case .stats, .venues, .artists, .settings:
+      case .stats, .venues, .artists, .settings, .search:
         break
       }
     }

--- a/Sources/Site/Resources/Localizable.xcstrings
+++ b/Sources/Site/Resources/Localizable.xcstrings
@@ -242,6 +242,9 @@
     "Retry" : {
 
     },
+    "Search" : {
+
+    },
     "See More About This Show" : {
 
     },

--- a/Tests/SiteTests/ArchiveCategoryTests.swift
+++ b/Tests/SiteTests/ArchiveCategoryTests.swift
@@ -12,7 +12,7 @@ import Testing
 
 let categoryPaths = [
   "/dates/today.html", "/stats.html", "/dates/stats.html", "/venues/stats.html",
-  "/bands/stats.html", "",
+  "/bands/stats.html", "", "",
 ]
 
 struct ArchiveCategoryTests {

--- a/Tests/SiteTests/ArchiveNavigationTests.swift
+++ b/Tests/SiteTests/ArchiveNavigationTests.swift
@@ -13,6 +13,7 @@ extension ArchiveCategory {
   var isRegularActivity: Bool {
     if case .stats = self { return false }
     if case .settings = self { return false }
+    if case .search = self { return false }
     return true
   }
 }


### PR DESCRIPTION
- Doing this this way since it touches so many files!
- This is necessary even with Tab's .search role. This is because your code needs a value that also means "search" for the Tab. If it is added to ArchiveTab, it must be added to ArchiveCategory too.
- This is so that ArchiveNavigation knows that it is showing Search so that when a search result is tapped on, the navigation to the ArchivePath will do the right thing and change from the Search tab to the right ArchiveCategory.