### PR TITLE
Store ShowsMode in SceneStorage

### DIFF
--- a/Sources/Site/Music/UI/ArchiveTabView.swift
+++ b/Sources/Site/Music/UI/ArchiveTabView.swift
@@ -90,6 +90,7 @@ extension ArchiveCategory {
 
 struct ArchiveTabView: View {
   @Environment(VaultModel.self) var model
+  @SceneStorage("shows.mode") private var showsMode = ShowsMode.default
 
   @Binding var venueSort: RankingSort
   @Binding var artistSort: RankingSort
@@ -99,8 +100,9 @@ struct ArchiveTabView: View {
   let reloadModel: @MainActor () async -> Void
   let navigateToPath: (ArchivePath) -> Void
 
-  @State var searchString: String = ""
-  @State var scope: ArchiveScope = .all
+  @State private var searchString: String = ""
+  @State private var scope: ArchiveScope = .all
+  @State private var selectedTab = ArchiveTab.default
 
   @ViewBuilder private var searchTabContent: some View {
     NavigationStack {
@@ -118,9 +120,6 @@ struct ArchiveTabView: View {
       }
     }
   }
-
-  @State private var selectedTab = ArchiveTab.default
-  @State private var showsMode = ShowsMode.default
 
   var body: some View {
     TabView(selection: $selectedTab) {

--- a/Sources/Site/Music/UI/ShowsMode.swift
+++ b/Sources/Site/Music/UI/ShowsMode.swift
@@ -5,7 +5,7 @@
 //  Created by Greg Bolsinga on 8/7/25.
 //
 
-enum ShowsMode: CaseIterable {
+enum ShowsMode: Int, CaseIterable {
   /// Shows Today Only.
   case ordinal
 


### PR DESCRIPTION
- ShowsMode must be RawRepresentable, so make the enum an Int.
- Group the @State in the view together for readability. Make some private too.
- Fixes #1065