### PR TITLE
Vault now has the lookup for ArchiveCategory URLs

### DIFF
--- a/Sources/MusicData/ArchiveCategory+URL.swift
+++ b/Sources/MusicData/ArchiveCategory+URL.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension ArchiveCategory {
-  fileprivate var isURLSharable: Bool {
+  var isURLSharable: Bool {
     switch self {
     case .today, .stats, .settings, .search:
       return false
@@ -17,16 +17,9 @@ extension ArchiveCategory {
     }
   }
 
-  fileprivate func url(rootURL: URL) -> URL? {
+  func url(rootURL: URL) -> URL? {
     var urlComponents = URLComponents(url: rootURL, resolvingAgainstBaseURL: false)
     urlComponents?.path = self.formatted(.urlPath)
     return urlComponents?.url
-  }
-
-  public static func urls(rootURL: URL) -> [ArchiveCategory: URL] {
-    self.allCases.filter { $0.isURLSharable }.reduce(into: [ArchiveCategory: URL]()) {
-      guard let url = $1.url(rootURL: rootURL) else { return }
-      $0[$1] = url
-    }
   }
 }

--- a/Sources/MusicData/Vault.swift
+++ b/Sources/MusicData/Vault.swift
@@ -23,6 +23,8 @@ public struct Vault: Sendable {
 
   public let decadesMap: [Decade: [Annum: [Show.ID]]]
 
+  private let categoryURLLookup: [ArchiveCategory: URL]
+
   public init(music: Music, url: URL) {
     // non-parallel, used for previews, tests
     let lookup = Lookup(music: music)
@@ -63,6 +65,11 @@ public struct Vault: Sendable {
     self.venueDigestMap = self.venueDigests.reduce(into: [:]) { $0[$1.venue.id] = $1 }
 
     self.decadesMap = decadesMap
+
+    self.categoryURLLookup = ArchiveCategory.allCases.reduce(into: [ArchiveCategory: URL]()) {
+      guard let url = $1.url(rootURL: rootURL) else { return }
+      $0[$1] = url
+    }
   }
 
   public static func create(music: Music, url: URL) async -> Vault {
@@ -113,5 +120,14 @@ public struct Vault: Sendable {
       result += concerts.filter { $0.id == id }
     }
     return result.sorted { comparator.compare(lhs: $0, rhs: $1) }
+  }
+
+  /// The URL for this category. Works in the app, always. May not have a equivalent on the web.
+  public func url(for category: ArchiveCategory) -> URL? {
+    categoryURLLookup[category]
+  }
+
+  public func sharableURL(for category: ArchiveCategory) -> URL? {
+    category.isURLSharable ? url(for: category) : nil
   }
 }

--- a/Sources/Site/Music/UI/ArchiveCategoryToolbarContent.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryToolbarContent.swift
@@ -45,6 +45,7 @@ struct ArchiveCategoryToolbarContent: ToolbarContent {
       LocationFilterToolbarContent { showNearbyDistanceSettings = true }
     }
     ArchiveSharableToolbarContent(
-      item: ArchiveCategoryLinkable(category: category, url: model.categoryURLMap[category]))
+      item: ArchiveCategoryLinkable(
+        category: category, url: model.vault.sharableURL(for: category)))
   }
 }

--- a/Sources/Site/Music/UI/ArchiveStateView.swift
+++ b/Sources/Site/Music/UI/ArchiveStateView.swift
@@ -48,7 +48,7 @@ struct ArchiveStateView: View {
       }
       .onOpenURL { archiveNavigation.openURL($0) }
       .advertiseUserActivity(
-        for: archiveNavigation.activity, urlForCategory: { model.categoryURLMap[$0] }
+        for: archiveNavigation.activity, urlForCategory: { model.vault.sharableURL(for: $0) }
       ) {
         model.vault.restorableSharableLinkable(for: $0)
       }

--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -47,12 +47,9 @@ enum LocationAuthorization {
 
   private let atlas = Atlas<Venue>()
 
-  let categoryURLMap: [ArchiveCategory: URL]
-
   @MainActor
   internal init(_ vault: Vault, executeAsynchronousTasks: Bool) {
     self.vault = vault
-    self.categoryURLMap = ArchiveCategory.urls(rootURL: vault.rootURL)
 
     updateTodayConcerts()
 


### PR DESCRIPTION
- This will allow MusicData to be used by Intents and just open universal URLs in the app.
- Sharable URLs are all that are used by NSUserActivity and ShareLink, since those must be web accessible.