### PR TITLE
Fix macos search tab

### DIFF
--- a/Sources/Site/Music/UI/ArchiveTabView.swift
+++ b/Sources/Site/Music/UI/ArchiveTabView.swift
@@ -84,7 +84,7 @@ struct ArchiveTabView: View {
             .badge(category.badge(model))
           #endif
         } else {
-          #if os(macOS) && swift(<6.2)
+          #if os(macOS)
             Tab(category.localizedString, systemImage: category.systemImage, value: category) {
               searchTabContent
             }


### PR DESCRIPTION
Search role is not working on Sequoia (regardless of Swift 6.2). When running on Tahoe, the search role works.