### PR TITLE
Use handlesExternalEvents to get handoff to open in the same window on macos

### DIFF
--- a/Sources/Site/Music/UI/ArchiveStateView.swift
+++ b/Sources/Site/Music/UI/ArchiveStateView.swift
@@ -47,7 +47,9 @@ struct ArchiveStateView: View {
         archiveNavigation.categoryActivity($0)
       }
       .onOpenURL { archiveNavigation.openURL($0) }
-      .handlesExternalEvents(preferring: ["*"], allowing: ["*"])
+      #if !os(tvOS)
+        .handlesExternalEvents(preferring: ["*"], allowing: ["*"])
+      #endif
       .advertiseUserActivity(
         for: archiveNavigation.activity, urlForCategory: { model.vault.url(for: $0) }
       ) {

--- a/Sources/Site/Music/UI/ArchiveStateView.swift
+++ b/Sources/Site/Music/UI/ArchiveStateView.swift
@@ -47,6 +47,7 @@ struct ArchiveStateView: View {
         archiveNavigation.categoryActivity($0)
       }
       .onOpenURL { archiveNavigation.openURL($0) }
+      .handlesExternalEvents(preferring: ["*"], allowing: ["*"])
       .advertiseUserActivity(
         for: archiveNavigation.activity, urlForCategory: { model.vault.url(for: $0) }
       ) {


### PR DESCRIPTION
- Opening a universal URL on macOS Sequoia will still not open the proper location on macOS. However the same url works for `NSUserActivity`.
- Building macOS on Tahoe in a Virtual Machine fails when the universal links entitlement is added, so this will have to be revisited once development is primarily on Tahoe.