### PR TITLE
Atlas cache file is Venue.ID -> CLPlacemark data

### DIFF
--- a/Sources/Site/Music/Atlas.swift
+++ b/Sources/Site/Music/Atlas.swift
@@ -17,8 +17,8 @@ protocol Geocodable {
   func geocode() async throws -> Place
 }
 
-protocol AtlasGeocodable: Geocodable, Codable, Equatable, Hashable, Sendable
-where Place: Codable & Sendable {}
+protocol AtlasGeocodable: Geocodable, Identifiable, Sendable
+where ID: Codable, Place: Codable & Sendable {}
 
 private enum Constants {
   static let maxRequests = 50


### PR DESCRIPTION
It used to be the entire `Venue`. Now it is just the `Venue.ID`. Launching again will re-geocode everything, which is fine.