### PR TITLE
Add DayBrowser

### DIFF
--- a/SiteApp.xcodeproj/project.pbxproj
+++ b/SiteApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		FE00A5EE2EA69913003DE0C6 /* Date+DayOfLeapYear.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00A5EC2EA69913003DE0C6 /* Date+DayOfLeapYear.swift */; };
 		FE00A5EF2EA69913003DE0C6 /* Date+DayOfLeapYear.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00A5EC2EA69913003DE0C6 /* Date+DayOfLeapYear.swift */; };
 		FE00A5F12EA69B2A003DE0C6 /* DayOfLeapYearTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00A5F02EA69B2A003DE0C6 /* DayOfLeapYearTests.swift */; };
+		FE00A5F52EAE7945003DE0C6 /* DayBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00A5F42EAE7945003DE0C6 /* DayBrowser.swift */; };
 		FE42CBC42E739F640064F683 /* ArtistEntityQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE42CBC32E739F640064F683 /* ArtistEntityQuery.swift */; };
 		FE42CBC62E739F810064F683 /* EntityQuerySort+SortOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE42CBC52E739F810064F683 /* EntityQuerySort+SortOrder.swift */; };
 		FE42CBC82E73A0900064F683 /* ArtistEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE42CBC72E73A0900064F683 /* ArtistEntity.swift */; };
@@ -433,6 +434,7 @@
 /* Begin PBXFileReference section */
 		FE00A5EC2EA69913003DE0C6 /* Date+DayOfLeapYear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+DayOfLeapYear.swift"; sourceTree = "<group>"; };
 		FE00A5F02EA69B2A003DE0C6 /* DayOfLeapYearTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOfLeapYearTests.swift; sourceTree = "<group>"; };
+		FE00A5F42EAE7945003DE0C6 /* DayBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayBrowser.swift; sourceTree = "<group>"; };
 		FE42CBC32E739F640064F683 /* ArtistEntityQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistEntityQuery.swift; sourceTree = "<group>"; };
 		FE42CBC52E739F810064F683 /* EntityQuerySort+SortOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EntityQuerySort+SortOrder.swift"; sourceTree = "<group>"; };
 		FE42CBC72E73A0900064F683 /* ArtistEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistEntity.swift; sourceTree = "<group>"; };
@@ -882,6 +884,7 @@
 				FE57C29B2E713D1300A67D4F /* Bundle+AppIcon.swift */,
 				FEE44E802E9184C80080998E /* ChartTitle.swift */,
 				FE57C29C2E713D1300A67D4F /* ConcertBlurb.swift */,
+				FE00A5F42EAE7945003DE0C6 /* DayBrowser.swift */,
 				FE57C2BC2E713D1300A67D4F /* DayList.swift */,
 				FE57C29D2E713D1300A67D4F /* DaysShowsSummary.swift */,
 				FE57C2BD2E713D1300A67D4F /* DaySummary.swift */,
@@ -1428,6 +1431,7 @@
 				FE57C36B2E713D1300A67D4F /* PathRestorableLink.swift in Sources */,
 				FE57C36C2E713D1300A67D4F /* RankableSortList.swift in Sources */,
 				FE57C36D2E713D1300A67D4F /* Ranking+RankingSort.swift in Sources */,
+				FE00A5F52EAE7945003DE0C6 /* DayBrowser.swift in Sources */,
 				FE57C36E2E713D1300A67D4F /* Ranking+ViewRepresentations.swift in Sources */,
 				FE57C36F2E713D1300A67D4F /* RankingList.swift in Sources */,
 				FE57C3702E713D1300A67D4F /* RefreshCommand.swift in Sources */,

--- a/Sources/Site/Music/UI/DayBrowser.swift
+++ b/Sources/Site/Music/UI/DayBrowser.swift
@@ -1,0 +1,67 @@
+//
+//  DayBrowser.swift
+//  site
+//
+//  Created by Greg Bolsinga on 9/23/24.
+//
+
+import SwiftUI
+
+struct DayBrowser: View {
+  @Environment(VaultModel.self) var model
+
+  enum DayTab: Int {
+    case yesterday
+    case today
+    case tomorrow
+  }
+
+  @State private var dayOfLeapYear: Int = 1
+  @State private var selection: DayTab = .today
+
+  @ViewBuilder private func dayList(_ dayOfLeapYear: Int) -> some View {
+    DayList(concerts: model.concerts(on: dayOfLeapYear), dayOfLeapYear: dayOfLeapYear)
+  }
+
+  var body: some View {
+    TabView(selection: $selection) {
+      Tab(value: DayTab.yesterday) {
+        dayList(dayOfLeapYear.previousDayOfLeapYear)
+      }
+
+      Tab(value: DayTab.today) {
+        dayList(dayOfLeapYear)
+          .onDisappear {
+            switch selection {
+            case .yesterday:
+              dayOfLeapYear = dayOfLeapYear.previousDayOfLeapYear
+            case .today:
+              break
+            case .tomorrow:
+              dayOfLeapYear = dayOfLeapYear.nextDayOfLeapYear
+            }
+
+            selection = .today
+          }
+      }
+
+      Tab(value: DayTab.tomorrow) {
+        dayList(dayOfLeapYear.nextDayOfLeapYear)
+      }
+    }
+    .navigationTitle(Text("On This Day: \(dayOfLeapYear.dayOfLeapYearFormatted)"))  // need this here for ipad
+    .onAppear {
+      self.dayOfLeapYear = model.todayDayOfLeapYear
+    }
+    #if !os(macOS)
+      .indexViewStyle(.page(backgroundDisplayMode: .always))
+      .tabViewStyle(.page(indexDisplayMode: .automatic))
+    #endif
+  }
+}
+
+#Preview(traits: .vaultModel) {
+  NavigationStack {
+    DayBrowser()
+  }
+}

--- a/Sources/Site/Music/UI/DaySummary.swift
+++ b/Sources/Site/Music/UI/DaySummary.swift
@@ -17,7 +17,11 @@ struct DaySummary: View {
   @Environment(VaultModel.self) var model
 
   var body: some View {
-    DayList(model: model, dayOfLeapYear: Date.now.dayOfLeapYear)
+    #if os(macOS)
+      DayList(model: model, dayOfLeapYear: Date.now.dayOfLeapYear)
+    #else
+      DayBrowser()
+    #endif
   }
 }
 

--- a/Sources/Utilities/Date+DayOfLeapYear.swift
+++ b/Sources/Utilities/Date+DayOfLeapYear.swift
@@ -35,16 +35,44 @@ extension Int {
     return dateComponents
   }
 
+  private var leapYeapDayRange: Range<Int>? {
+    guard let leapYearDate = leapYearComponents.date else { return nil }
+    return Calendar.autoupdatingCurrent.range(of: .day, in: .year, for: leapYearDate)
+  }
+
   private var isValidDayOfLeapYear: Bool {
-    guard let leapYearDate = leapYearComponents.date else { return false }
-    guard let range = Calendar.autoupdatingCurrent.range(of: .day, in: .year, for: leapYearDate)
-    else { return false }
-    return range.contains(self)
+    guard let leapYeapDayRange = leapYeapDayRange else { return false }
+    return leapYeapDayRange.contains(self)
   }
 
   var dayOfLeapYearFormatted: String {
     guard isValidDayOfLeapYear else { return "" }
     guard let dayOfLeapYearDate = dayOfLeapYearComponents.date else { return "" }
     return dayOfLeapYearDate.formatted(.dateTime.month(.defaultDigits).day())
+  }
+
+  private func offsetDayOfLeapYear(by offset: Int) -> Int {
+    guard let leapYeapDayRange = leapYeapDayRange else { return -1 }
+
+    let newDayOfLeapYear = self + offset
+
+    if newDayOfLeapYear < leapYeapDayRange.lowerBound {
+      return leapYeapDayRange.count
+    }
+    if newDayOfLeapYear >= leapYeapDayRange.upperBound {
+      return 1
+    }
+
+    return newDayOfLeapYear
+  }
+
+  var nextDayOfLeapYear: Int {
+    guard isValidDayOfLeapYear else { return -1 }
+    return offsetDayOfLeapYear(by: 1)
+  }
+
+  var previousDayOfLeapYear: Int {
+    guard isValidDayOfLeapYear else { return -1 }
+    return offsetDayOfLeapYear(by: -1)
   }
 }

--- a/Tests/UtilitiesTests/DayOfLeapYearTests.swift
+++ b/Tests/UtilitiesTests/DayOfLeapYearTests.swift
@@ -86,4 +86,20 @@ struct DayOfLeapYearTests {
     #expect(61.dayOfLeapYearFormatted == "3/1")
     #expect(366.dayOfLeapYearFormatted == "12/31")
   }
+
+  @Test func next() async throws {
+    #expect(0.nextDayOfLeapYear == -1)
+    #expect(1.nextDayOfLeapYear == 2)
+    #expect(365.nextDayOfLeapYear == 366)
+    #expect(366.nextDayOfLeapYear == 1)
+    #expect(367.nextDayOfLeapYear == -1)
+  }
+
+  @Test func previous() async throws {
+    #expect(0.previousDayOfLeapYear == -1)
+    #expect(1.previousDayOfLeapYear == 366)
+    #expect(365.previousDayOfLeapYear == 364)
+    #expect(366.previousDayOfLeapYear == 365)
+    #expect(367.previousDayOfLeapYear == -1)
+  }
 }


### PR DESCRIPTION
- allows swiping through the days side to side. So you can see what shows you saw yesterday or tomorrow, etc.
- disabled on macos at this time (since it doesn't support .page in TabView).
- allows infinite swiping through all days of the year, including leap day!
- Fixes #250