### PR TITLE
Fix navigation from DayBrowser

### DIFF
--- a/Sources/Site/Music/UI/ArchiveCategoryStack.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryStack.swift
@@ -29,6 +29,8 @@ struct ArchiveCategoryStack: View {
 
   @State private var showNearbyDistanceSettings: Bool = false
 
+  @State private var dayOfLeapYear = Date.now.dayOfLeapYear
+
   private var showToolbar: Bool {
     switch category {
     case .today, .venues, .artists, .stats, .settings, .search:
@@ -41,12 +43,12 @@ struct ArchiveCategoryStack: View {
   @ViewBuilder private var summary: some View {
     switch category {
     case .today:
-      DaySummary()
+      DaySummary(dayOfLeapYear: $dayOfLeapYear)
     case .stats:
       StatsSummary()
     case .shows:
       if combineTodayAndShowSummary {
-        DaysShowsSummary(mode: $showsMode)
+        DaysShowsSummary(mode: $showsMode, dayOfLeapYear: $dayOfLeapYear)
       } else {
         ShowsSummary()
       }

--- a/Sources/Site/Music/UI/DayBrowser.swift
+++ b/Sources/Site/Music/UI/DayBrowser.swift
@@ -16,7 +16,7 @@ struct DayBrowser: View {
     case tomorrow
   }
 
-  @State private var dayOfLeapYear: Int = 1
+  @Binding var dayOfLeapYear: Int
   @State private var selection: DayTab = .today
 
   @ViewBuilder private func dayList(_ dayOfLeapYear: Int) -> some View {
@@ -50,9 +50,6 @@ struct DayBrowser: View {
       }
     }
     .navigationTitle(dayOfLeapYear.relativeTitle)  // need this here for ipad
-    .onAppear {
-      self.dayOfLeapYear = model.todayDayOfLeapYear
-    }
     #if !os(macOS)
       .indexViewStyle(.page(backgroundDisplayMode: .always))
       .tabViewStyle(.page(indexDisplayMode: .automatic))
@@ -61,7 +58,9 @@ struct DayBrowser: View {
 }
 
 #Preview(traits: .vaultModel) {
+  @Previewable @State var dayOfLeapYear = Date.now.dayOfLeapYear
+
   NavigationStack {
-    DayBrowser()
+    DayBrowser(dayOfLeapYear: $dayOfLeapYear)
   }
 }

--- a/Sources/Site/Music/UI/DaySummary.swift
+++ b/Sources/Site/Music/UI/DaySummary.swift
@@ -16,17 +16,21 @@ extension DayList {
 struct DaySummary: View {
   @Environment(VaultModel.self) var model
 
+  @Binding var dayOfLeapYear: Int
+
   var body: some View {
     #if os(macOS)
-      DayList(model: model, dayOfLeapYear: Date.now.dayOfLeapYear)
+      DayList(model: model, dayOfLeapYear: dayOfLeapYear)
     #else
-      DayBrowser()
+      DayBrowser(dayOfLeapYear: $dayOfLeapYear)
     #endif
   }
 }
 
 #Preview(traits: .vaultModel) {
+  @Previewable @State var dayOfLeapYear = Date.now.dayOfLeapYear
+
   NavigationStack {
-    DaySummary()
+    DaySummary(dayOfLeapYear: $dayOfLeapYear)
   }
 }

--- a/Sources/Site/Music/UI/DaysShowsSummary.swift
+++ b/Sources/Site/Music/UI/DaysShowsSummary.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct DaysShowsSummary: View {
   @Binding var mode: ShowsMode
+  @Binding var dayOfLeapYear: Int
 
   var body: some View {
     Picker(selection: $mode) {
@@ -21,7 +22,7 @@ struct DaysShowsSummary: View {
 
     switch mode {
     case .ordinal:
-      DaySummary()
+      DaySummary(dayOfLeapYear: $dayOfLeapYear)
     case .grouped:
       ShowsSummary()
     }
@@ -30,7 +31,9 @@ struct DaysShowsSummary: View {
 
 #Preview(traits: .vaultModel, .nearbyModel) {
   @Previewable @State var showsMode = ShowsMode.ordinal
+  @Previewable @State var dayOfLeapYear = Date.now.dayOfLeapYear
+
   NavigationStack {
-    DaysShowsSummary(mode: $showsMode)
+    DaysShowsSummary(mode: $showsMode, dayOfLeapYear: $dayOfLeapYear)
   }
 }


### PR DESCRIPTION
- Hold the dayOfLeapYear state in ArchiveCategoryStack
- This way digging into a different day's shows and going back will take you back to the different day.