### PR TITLE
Placemark now contains a CLLocation

### DIFF
--- a/Sources/Site/Music/Geocode.swift
+++ b/Sources/Site/Music/Geocode.swift
@@ -13,10 +13,12 @@ private enum GeocodeError: Error {
 
 extension String: Geocodable {
   func geocode() async throws -> Placemark {
-    guard let placemark = try await CLGeocoder().geocodeAddressString(self).first else {
+    guard let placemark = try await CLGeocoder().geocodeAddressString(self).first,
+      let location = placemark.location
+    else {
       throw GeocodeError.noPlacemark
     }
-    return Placemark(placemark: placemark)
+    return Placemark(location: location)
   }
 }
 
@@ -25,10 +27,12 @@ extension String: Geocodable {
 
   extension CNPostalAddress: Geocodable {
     func geocode() async throws -> Placemark {
-      guard let placemark = try await CLGeocoder().geocodePostalAddress(self).first else {
+      guard let placemark = try await CLGeocoder().geocodePostalAddress(self).first,
+        let location = placemark.location
+      else {
         throw GeocodeError.noPlacemark
       }
-      return Placemark(placemark: placemark)
+      return Placemark(location: location)
     }
   }
 #endif

--- a/Sources/Site/Music/Location+Geocode.swift
+++ b/Sources/Site/Music/Location+Geocode.swift
@@ -13,7 +13,7 @@ import Foundation
 
 extension Location: Geocodable {
   #if canImport(Contacts)
-    private var postalAddress: CNPostalAddress {
+    var postalAddress: CNPostalAddress {
       let pAddress = CNMutablePostalAddress()
       pAddress.city = city
       pAddress.state = state

--- a/Sources/Site/Music/Placemark.swift
+++ b/Sources/Site/Music/Placemark.swift
@@ -9,11 +9,11 @@ import CoreLocation
 
 struct Placemark: Codable, Sendable {
   @NSCodingCodable
-  var placemark: CLPlacemark
+  var location: CLLocation
 }
 
 extension Placemark: Locatable {
   func nearby(to otherLocation: CLLocation, distanceThreshold: CLLocationDistance) -> Bool {
-    placemark.nearby(to: otherLocation, distanceThreshold: distanceThreshold)
+    location.nearby(to: otherLocation, distanceThreshold: distanceThreshold)
   }
 }

--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -251,7 +251,7 @@ enum LocationAuthorization {
 
   @MainActor
   func geocode(_ venue: Venue) async throws -> MKMapItem? {
-    guard let placemark = try await atlas.geocode(venue)?.placemark else { return nil }
-    return MKMapItem(placemark: MKPlacemark(placemark: placemark))
+    guard let location = try await atlas.geocode(venue)?.location else { return nil }
+    return MKMapItem(venue: venue, location: location)
   }
 }

--- a/Sources/Site/Music/Venue+MapItem.swift
+++ b/Sources/Site/Music/Venue+MapItem.swift
@@ -1,0 +1,24 @@
+//
+//  Venue+MapItem.swift
+//  SiteApp
+//
+//  Created by Greg Bolsinga on 11/12/25.
+//
+
+import MapKit
+
+#if canImport(Contacts)
+  import Contacts
+#endif
+
+extension MKMapItem {
+  convenience init(venue: Venue, location: CLLocation) {
+    #if canImport(Contacts)
+      let placemark = MKPlacemark(
+        location: location, name: venue.name, postalAddress: venue.location.postalAddress)
+    #else
+      let placemark = MKPlacemark(coordinate: location.coordinate)
+    #endif
+    self.init(placemark: placemark)
+  }
+}

--- a/Sources/Site/Utility/Location+Locatable.swift
+++ b/Sources/Site/Utility/Location+Locatable.swift
@@ -1,0 +1,14 @@
+//
+//  Location+Locatable.swift
+//  SiteApp
+//
+//  Created by Greg Bolsinga on 11/12/25.
+//
+
+import CoreLocation
+
+extension CLLocation: Locatable {
+  func nearby(to otherLocation: CLLocation, distanceThreshold: CLLocationDistance) -> Bool {
+    distance(from: otherLocation) <= distanceThreshold
+  }
+}

--- a/Sources/Site/Utility/Placemark+Geometry.swift
+++ b/Sources/Site/Utility/Placemark+Geometry.swift
@@ -16,13 +16,4 @@ extension CLPlacemark {
     guard let circularRegion = self.region as? CLCircularRegion else { return 100.0 }  // meters
     return circularRegion.radius
   }
-
-  private func distance(from otherLocation: CLLocation) -> CLLocationDistance {
-    guard let location else { return CLLocationDistanceMax }
-    return location.distance(from: otherLocation)
-  }
-
-  func nearby(to otherLocation: CLLocation, distanceThreshold: CLLocationDistance) -> Bool {
-    return distance(from: otherLocation) <= distanceThreshold
-  }
 }


### PR DESCRIPTION
- This should help with migrating to MKGeocodingRequest. The issue is the MKMapItem is not Codable nor NSSecureCoding. CLPlacemark is, but is gone in OS 26.