### PR TITLE
Use role .close on macOS 26

### DIFF
--- a/Sources/App/Localizable.xcstrings
+++ b/Sources/App/Localizable.xcstrings
@@ -234,6 +234,9 @@
     "City" : {
 
     },
+    "Close" : {
+
+    },
     "club" : {
 
     },
@@ -271,9 +274,6 @@
 
     },
     "Displays Venue Details in App." : {
-
-    },
-    "Done" : {
 
     },
     "Edit Nearby Distance" : {

--- a/Sources/Site/Music/UI/DismissibleSheetModifier.swift
+++ b/Sources/Site/Music/UI/DismissibleSheetModifier.swift
@@ -17,8 +17,11 @@ struct DismissibleSheetModifier<SheetContent>: ViewModifier where SheetContent: 
         VStack {
           sheetContent()
           #if os(macOS)
-            // FIXME : 26 add role: .close
-            Button("Done") { showSheet = false }
+          if #available(macOS 26, *) {
+            Button(role: .close) { showSheet = false }
+          } else {
+            Button("Close") { showSheet = false }
+          }
           #endif
         }
         .padding(10)


### PR DESCRIPTION
- Use "Close" as the text prior to os 26, to match what os 26 displays.