### PR TITLE
rootURL is in Environment via VaultModel

### DIFF
--- a/Sources/Intents/ArtistEntity.swift
+++ b/Sources/Intents/ArtistEntity.swift
@@ -41,8 +41,7 @@ struct ArtistEntity: AppEntity {
       title: "\(name)", image: .init(systemName: "person.and.background.dotted"))
   }
 
-  init?(digest: ArtistDigest) {
-    guard let url = digest.url else { return nil }
+  init(digest: ArtistDigest, url: URL) {
     self.id = digest.id
     self.url = url
     self.name = digest.name

--- a/Sources/Intents/ArtistEntityQuery.swift
+++ b/Sources/Intents/ArtistEntityQuery.swift
@@ -24,13 +24,20 @@ extension Sequence where Element == Concert {
   }
 }
 
+extension Vault {
+  fileprivate func entity(for digest: ArtistDigest) -> ArtistEntity? {
+    guard let url = url(for: digest) else { return nil }
+    return ArtistEntity(digest: digest, url: url)
+  }
+}
+
 struct ArtistEntityQuery: EntityQuery {
   func entities(for identifiers: [ArtistEntity.ID]) async throws -> [ArtistEntity] {
     Logger.artistQuery.log("Identifiers: \(identifiers)")
 
     return identifiers.reduce(into: [ArtistEntity]()) { partialResult, id in
       guard let digest = vault.artistDigestMap[id] else { return }
-      guard let entity = ArtistEntity(digest: digest) else { return }
+      guard let entity = vault.entity(for: digest) else { return }
       partialResult.append(entity)
     }
   }
@@ -54,7 +61,7 @@ extension ArtistEntityQuery: EntityStringQuery {
   func entities(matching string: String) async throws -> [ArtistEntity] {
     Logger.artistQuery.log("Matching: \(string)")
 
-    return vault.artistDigests.names(filteredBy: string).compactMap { ArtistEntity(digest: $0) }
+    return vault.artistDigests.names(filteredBy: string).compactMap { vault.entity(for: $0) }
   }
 }
 
@@ -162,7 +169,7 @@ extension ArtistEntityQuery: EntityPropertyQuery {
   private func entities(matching comparators: [Predicate<ArtistEntity>], mode: ComparatorMode)
     throws -> [ArtistEntity]
   {
-    try vault.artistDigests.compactMap { ArtistEntity(digest: $0) }.compactMap { entity in
+    try vault.artistDigests.compactMap { vault.entity(for: $0) }.compactMap { entity in
       var includeAsResult = mode == .and ? true : false
       let earlyBreakCondition = includeAsResult
       for comparator in comparators {

--- a/Sources/Intents/VenueEntity.swift
+++ b/Sources/Intents/VenueEntity.swift
@@ -45,8 +45,7 @@ struct VenueEntity: AppEntity {
       title: "\(name)", subtitle: "\(address)", image: .init(systemName: "music.note.house"))
   }
 
-  init?(digest: VenueDigest) {
-    guard let url = digest.url else { return nil }
+  init(digest: VenueDigest, url: URL) {
     self.id = digest.id
     self.address = digest.venue.location.formatted(.oneLineNoURL)
 

--- a/Sources/MusicData/Annum+Digest.swift
+++ b/Sources/MusicData/Annum+Digest.swift
@@ -9,13 +9,12 @@ import Foundation
 
 extension Annum {
   fileprivate func digest(
-    concerts: [Concert], rootURL: URL, lookup: Lookup, comparator: (Concert, Concert) -> Bool
+    concerts: [Concert], lookup: Lookup, comparator: (Concert, Concert) -> Bool
   )
     -> AnnumDigest
   {
     AnnumDigest(
       annum: self,
-      url: archivePath.url(using: rootURL),
       concerts: concerts.filter { $0.show.date.annum == self }.sorted(by: comparator),
       showRank: lookup.showRank(annum: self),
       venueRank: lookup.venueRank(annum: self),
@@ -26,12 +25,10 @@ extension Annum {
 
 extension Array where Element == Annum {
   public func digests(
-    concerts: [Concert], rootURL: URL, lookup: Lookup, comparator: (Concert, Concert) -> Bool
+    concerts: [Concert], lookup: Lookup, comparator: (Concert, Concert) -> Bool
   )
     -> [AnnumDigest]
   {
-    self.map {
-      $0.digest(concerts: concerts, rootURL: rootURL, lookup: lookup, comparator: comparator)
-    }
+    self.map { $0.digest(concerts: concerts, lookup: lookup, comparator: comparator) }
   }
 }

--- a/Sources/MusicData/AnnumDigest.swift
+++ b/Sources/MusicData/AnnumDigest.swift
@@ -9,18 +9,16 @@ import Foundation
 
 public struct AnnumDigest: Sendable {
   public let annum: Annum
-  public let url: URL?
   public let concerts: [Concert]
   public let showRank: Ranking
   public let venueRank: Ranking
   public let artistRank: Ranking
 
   public init(
-    annum: Annum, url: URL? = nil, concerts: [Concert], showRank: Ranking, venueRank: Ranking,
+    annum: Annum, concerts: [Concert], showRank: Ranking, venueRank: Ranking,
     artistRank: Ranking
   ) {
     self.annum = annum
-    self.url = url
     self.concerts = concerts
     self.showRank = showRank
     self.venueRank = venueRank

--- a/Sources/MusicData/Artist+Digest.swift
+++ b/Sources/MusicData/Artist+Digest.swift
@@ -9,11 +9,10 @@ import Foundation
 
 extension Artist {
   fileprivate func digest(
-    concerts: [Concert], rootURL: URL, lookup: Lookup, comparator: (Concert, Concert) -> Bool
+    concerts: [Concert], lookup: Lookup, comparator: (Concert, Concert) -> Bool
   ) -> ArtistDigest {
     ArtistDigest(
       artist: self,
-      url: self.archivePath.url(using: rootURL),
       concerts: concerts.filter { $0.show.artists.contains(id) }.sorted(by: comparator),
       related: lookup.related(self),
       firstSet: lookup.firstSet(artist: self),
@@ -25,12 +24,12 @@ extension Artist {
 
 extension Array where Element == Artist {
   public func digests(
-    concerts: [Concert], rootURL: URL, lookup: Lookup, comparator: (Concert, Concert) -> Bool
+    concerts: [Concert], lookup: Lookup, comparator: (Concert, Concert) -> Bool
   )
     -> [ArtistDigest]
   {
     self.map {
-      $0.digest(concerts: concerts, rootURL: rootURL, lookup: lookup, comparator: comparator)
+      $0.digest(concerts: concerts, lookup: lookup, comparator: comparator)
     }
   }
 }

--- a/Sources/MusicData/ArtistDigest.swift
+++ b/Sources/MusicData/ArtistDigest.swift
@@ -11,7 +11,6 @@ public struct ArtistDigest: Equatable, Hashable, Identifiable, Sendable {
   public var id: Artist.ID { artist.id }
 
   public let artist: Artist
-  public let url: URL?
   public let concerts: [Concert]
   public let related: [Artist]
   public let firstSet: FirstSet
@@ -20,11 +19,10 @@ public struct ArtistDigest: Equatable, Hashable, Identifiable, Sendable {
   public let venueRank: Ranking
 
   public init(
-    artist: Artist, url: URL? = nil, concerts: [Concert], related: [Artist], firstSet: FirstSet,
+    artist: Artist, concerts: [Concert], related: [Artist], firstSet: FirstSet,
     spanRank: Ranking, showRank: Ranking, venueRank: Ranking
   ) {
     self.artist = artist
-    self.url = url
     self.concerts = concerts
     self.related = related
     self.firstSet = firstSet

--- a/Sources/MusicData/Concert.swift
+++ b/Sources/MusicData/Concert.swift
@@ -13,12 +13,10 @@ public struct Concert: Equatable, Hashable, Identifiable, Sendable {
   public let show: Show
   public let venue: Venue?
   public let artists: [Artist]
-  public let url: URL?
 
-  public init(show: Show, venue: Venue? = nil, artists: [Artist], url: URL? = nil) {
+  public init(show: Show, venue: Venue? = nil, artists: [Artist]) {
     self.show = show
     self.venue = venue
     self.artists = artists
-    self.url = url
   }
 }

--- a/Sources/MusicData/Show+Concert.swift
+++ b/Sources/MusicData/Show+Concert.swift
@@ -11,9 +11,7 @@ extension Show {
   fileprivate func concert(rootURL: URL, lookup: Lookup, comparator: (Concert, Concert) -> Bool)
     -> Concert
   {
-    Concert(
-      show: self, venue: lookup.venueForShow(self), artists: lookup.artistsForShow(self),
-      url: self.archivePath.url(using: rootURL))
+    Concert(show: self, venue: lookup.venueForShow(self), artists: lookup.artistsForShow(self))
   }
 }
 

--- a/Sources/MusicData/Vault.swift
+++ b/Sources/MusicData/Vault.swift
@@ -43,11 +43,11 @@ public struct Vault: Sendable {
     let concerts = await asyncConcerts
 
     async let artistDigests = music.artists.digests(
-      concerts: concerts, rootURL: url, lookup: lookup, comparator: comparator.compare(lhs:rhs:)
+      concerts: concerts, lookup: lookup, comparator: comparator.compare(lhs:rhs:)
     )
 
     async let venueDigests = music.venues.digests(
-      concerts: concerts, rootURL: url, lookup: lookup, comparator: comparator.compare(lhs:rhs:)
+      concerts: concerts, lookup: lookup, comparator: comparator.compare(lhs:rhs:)
     )
 
     self.comparator = comparator
@@ -65,7 +65,7 @@ public struct Vault: Sendable {
 
     self.decadesMap = await decadesMap
     self.annumDigestMap = self.decadesMap.values.flatMap { $0.keys }.digests(
-      concerts: concerts, rootURL: url, lookup: lookup, comparator: comparator.compare(lhs:rhs:)
+      concerts: concerts, lookup: lookup, comparator: comparator.compare(lhs:rhs:)
     ).reduce(into: [:]) { $0[$1.annum] = $1 }
 
     self.categoryURLLookup = ArchiveCategory.allCases.reduce(into: [ArchiveCategory: URL]()) {
@@ -93,5 +93,9 @@ public struct Vault: Sendable {
   /// The URL for this category.
   public func url(for category: ArchiveCategory) -> URL? {
     categoryURLLookup[category]
+  }
+
+  public func url(for item: PathRestorable) -> URL? {
+    item.archivePath.url(using: rootURL)
   }
 }

--- a/Sources/MusicData/Venue+Digest.swift
+++ b/Sources/MusicData/Venue+Digest.swift
@@ -9,11 +9,10 @@ import Foundation
 
 extension Venue {
   fileprivate func digest(
-    concerts: [Concert], rootURL: URL, lookup: Lookup, comparator: (Concert, Concert) -> Bool
+    concerts: [Concert], lookup: Lookup, comparator: (Concert, Concert) -> Bool
   ) -> VenueDigest {
     VenueDigest(
       venue: self,
-      url: self.archivePath.url(using: rootURL),
       concerts: concerts.filter { $0.show.venue == id }.sorted(by: comparator),
       related: lookup.related(self),
       firstSet: lookup.firstSet(venue: self),
@@ -25,10 +24,8 @@ extension Venue {
 
 extension Array where Element == Venue {
   public func digests(
-    concerts: [Concert], rootURL: URL, lookup: Lookup, comparator: (Concert, Concert) -> Bool
+    concerts: [Concert], lookup: Lookup, comparator: (Concert, Concert) -> Bool
   ) -> [VenueDigest] {
-    self.map {
-      $0.digest(concerts: concerts, rootURL: rootURL, lookup: lookup, comparator: comparator)
-    }
+    self.map { $0.digest(concerts: concerts, lookup: lookup, comparator: comparator) }
   }
 }

--- a/Sources/MusicData/VenueDigest.swift
+++ b/Sources/MusicData/VenueDigest.swift
@@ -11,7 +11,6 @@ public struct VenueDigest: Equatable, Hashable, Identifiable, Sendable {
   public var id: Venue.ID { venue.id }
 
   public let venue: Venue
-  public let url: URL?
   public let concerts: [Concert]
   public let related: [Venue]
   public let firstSet: FirstSet
@@ -20,11 +19,10 @@ public struct VenueDigest: Equatable, Hashable, Identifiable, Sendable {
   public let venueArtistRank: Ranking
 
   public init(
-    venue: Venue, url: URL? = nil, concerts: [Concert], related: [Venue], firstSet: FirstSet,
+    venue: Venue, concerts: [Concert], related: [Venue], firstSet: FirstSet,
     spanRank: Ranking, showRank: Ranking, venueArtistRank: Ranking
   ) {
     self.venue = venue
-    self.url = url
     self.concerts = concerts
     self.related = related
     self.firstSet = firstSet

--- a/Sources/Site/Music/AnnumDigest+NSUserActivity.swift
+++ b/Sources/Site/Music/AnnumDigest+NSUserActivity.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension AnnumDigest: PathRestorableUserActivity {
-  func updateActivity(_ userActivity: NSUserActivity) {
+  func updateActivity(_ userActivity: NSUserActivity, url: URL?) {
     userActivity.isEligibleForHandoff = true
 
     userActivity.isEligibleForSearch = true

--- a/Sources/Site/Music/ArtistDigest+NSUserActivity.swift
+++ b/Sources/Site/Music/ArtistDigest+NSUserActivity.swift
@@ -9,7 +9,7 @@ import AppIntents
 import Foundation
 
 extension ArtistDigest: PathRestorableUserActivity {
-  func updateActivity(_ userActivity: NSUserActivity) {
+  func updateActivity(_ userActivity: NSUserActivity, url: URL?) {
     userActivity.isEligibleForHandoff = true
 
     userActivity.isEligibleForSearch = true
@@ -17,8 +17,8 @@ extension ArtistDigest: PathRestorableUserActivity {
     userActivity.addSearchableContent(
       description: String(localized: "See Shows With This Artist"))
 
-    if let entity = ArtistEntity(digest: self) {
-      userActivity.appEntityIdentifier = EntityIdentifier(for: entity)
+    if let url {
+      userActivity.appEntityIdentifier = EntityIdentifier(for: ArtistEntity(digest: self, url: url))
     }
   }
 }

--- a/Sources/Site/Music/Concert+NSUserActivity.swift
+++ b/Sources/Site/Music/Concert+NSUserActivity.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Concert: PathRestorableUserActivity {
-  func updateActivity(_ userActivity: NSUserActivity) {
+  func updateActivity(_ userActivity: NSUserActivity, url: URL?) {
     userActivity.isEligibleForHandoff = true
 
     userActivity.isEligibleForSearch = true

--- a/Sources/Site/Music/NSUserActivity+ArchivePath.swift
+++ b/Sources/Site/Music/NSUserActivity+ArchivePath.swift
@@ -16,18 +16,18 @@ extension Logger {
 extension NSUserActivity {
   internal static let archivePathKey = "archivePath"
 
-  func update<T: PathRestorableUserActivity>(_ item: T) {
+  func update<T: PathRestorableUserActivity>(_ item: T, url: URL?) {
     let identifier = item.archivePath.formatted(.json)
     Logger.updateActivity.log("advertise: \(identifier, privacy: .public)")
     self.targetContentIdentifier = identifier
 
-    if let url = item.url {
+    if let url {
       Logger.updateActivity.log("web: \(url.absoluteString, privacy: .public)")
       self.isEligibleForPublicIndexing = true
       self.webpageURL = url
     }
 
-    item.updateActivity(self)
+    item.updateActivity(self, url: url)
 
     self.requiredUserInfoKeys = [NSUserActivity.archivePathKey]
     self.addUserInfoEntries(from: [NSUserActivity.archivePathKey: identifier])

--- a/Sources/Site/Music/PathRestorableUserActivity.swift
+++ b/Sources/Site/Music/PathRestorableUserActivity.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-protocol PathRestorableUserActivity: Linkable, PathRestorable {
-  func updateActivity(_ userActivity: NSUserActivity)
+protocol PathRestorableUserActivity: PathRestorable {
+  func updateActivity(_ userActivity: NSUserActivity, url: URL?)
 }

--- a/Sources/Site/Music/UI/ArchiveCategorySharable.swift
+++ b/Sources/Site/Music/UI/ArchiveCategorySharable.swift
@@ -1,5 +1,5 @@
 //
-//  ArchiveCategoryLinkable.swift
+//  ArchiveCategorySharable.swift
 //  site
 //
 //  Created by Greg Bolsinga on 10/5/24.
@@ -7,9 +7,8 @@
 
 import Foundation
 
-struct ArchiveCategoryLinkable: ArchiveSharable {
+struct ArchiveCategorySharable: ArchiveSharable {
   let category: ArchiveCategory
-  let url: URL?
 
   var subject: String { category.title }
   var message: String { subject }

--- a/Sources/Site/Music/UI/ArchiveCategoryToolbarContent.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryToolbarContent.swift
@@ -44,7 +44,7 @@ struct ArchiveCategoryToolbarContent: ToolbarContent {
       LocationFilterToolbarContent { showNearbyDistanceSettings = true }
     }
     ArchiveSharableToolbarContent(
-      item: ArchiveCategoryLinkable(
-        category: category, url: model.vault.url(for: category)))
+      item: ArchiveCategorySharable(
+        category: category), url: model.vault.url(for: category))
   }
 }

--- a/Sources/Site/Music/UI/ArchiveNavigationUserActivityModifier.swift
+++ b/Sources/Site/Music/UI/ArchiveNavigationUserActivityModifier.swift
@@ -25,6 +25,8 @@ struct ArchiveNavigationUserActivityModifier: ViewModifier {
   let urlForCategory: (ArchiveCategory) -> URL?
   let activityForPath: (ArchivePath) -> PathRestorableUserActivity?
 
+  @Environment(VaultModel.self) private var model
+
   func body(content: Content) -> some View {
     Logger.navigationUserActivity.log("activity: \(activity, privacy: .public)")
     return
@@ -40,7 +42,7 @@ struct ArchiveNavigationUserActivityModifier: ViewModifier {
 
         Logger.navigationUserActivity.log("update path \(path.formatted(.json), privacy: .public)")
         guard let pathUserActivity = activityForPath(path) else { return }
-        userActivity.update(pathUserActivity)
+        userActivity.update(pathUserActivity, url: model.vault.url(for: pathUserActivity))
       }
   }
 }

--- a/Sources/Site/Music/UI/ArchiveSharable.swift
+++ b/Sources/Site/Music/UI/ArchiveSharable.swift
@@ -12,7 +12,7 @@ import Foundation
 // When sharing via Mail, subject is as expected, and message is link followed by message text.
 // macos ventura: no subject nor message shown messages nor mail
 
-protocol ArchiveSharable: Linkable {
+protocol ArchiveSharable {
   var subject: String { get }
   var message: String { get }
 }

--- a/Sources/Site/Music/UI/ArchiveSharableToolbarContent.swift
+++ b/Sources/Site/Music/UI/ArchiveSharableToolbarContent.swift
@@ -10,14 +10,16 @@ import SwiftUI
 struct ArchiveSharableToolbarContent<T: ArchiveSharable>: ToolbarContent {
   let placement: ToolbarItemPlacement
   let item: T
+  let url: URL?
 
-  internal init(placement: ToolbarItemPlacement = .primaryAction, item: T) {
+  internal init(placement: ToolbarItemPlacement = .primaryAction, item: T, url: URL?) {
     self.placement = placement
     self.item = item
+    self.url = url
   }
 
   var body: some ToolbarContent {
-    if let url = item.url {
+    if let url {
       ToolbarItem(placement: placement) {
         #if !os(tvOS)
           ShareLink(

--- a/Sources/Site/Music/UI/ArtistDetail.swift
+++ b/Sources/Site/Music/UI/ArtistDetail.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ArtistDetail: View {
+  @Environment(VaultModel.self) private var model
+
   let digest: ArtistDigest
   let concertCompare: (Concert, Concert) -> Bool
   let isPathNavigable: (ArchivePath) -> Bool
@@ -69,7 +71,7 @@ struct ArtistDetail: View {
       .listStyle(.grouped)
     #endif
     .navigationTitle(digest.artist.name)
-    .toolbar { ArchiveSharableToolbarContent(item: digest) }
+    .toolbar { ArchiveSharableToolbarContent(item: digest, url: model.vault.url(for: digest)) }
   }
 }
 

--- a/Sources/Site/Music/UI/ShowDetail.swift
+++ b/Sources/Site/Music/UI/ShowDetail.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ShowDetail: View {
+  @Environment(VaultModel.self) private var model
+
   let concert: Concert
   let isPathNavigable: (ArchivePath) -> Bool
 
@@ -63,7 +65,7 @@ struct ShowDetail: View {
       .listStyle(.grouped)
     #endif
     .navigationTitle(venueName)
-    .toolbar { ArchiveSharableToolbarContent(item: concert) }
+    .toolbar { ArchiveSharableToolbarContent(item: concert, url: model.vault.url(for: concert)) }
   }
 }
 

--- a/Sources/Site/Music/UI/VenueDetail.swift
+++ b/Sources/Site/Music/UI/VenueDetail.swift
@@ -13,6 +13,8 @@ private enum VenueDetailGeocodeError: Error {
 }
 
 struct VenueDetail: View {
+  @Environment(VaultModel.self) private var model
+
   typealias geocoder = @MainActor (VenueDigest) async throws -> MKMapItem?
 
   let digest: VenueDigest
@@ -82,7 +84,7 @@ struct VenueDetail: View {
       .listStyle(.grouped)
     #endif
     .navigationTitle(digest.venue.name)
-    .toolbar { ArchiveSharableToolbarContent(item: digest) }
+    .toolbar { ArchiveSharableToolbarContent(item: digest, url: model.vault.url(for: digest)) }
   }
 }
 

--- a/Sources/Site/Music/UI/YearDetail.swift
+++ b/Sources/Site/Music/UI/YearDetail.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct YearDetail: View {
+  @Environment(VaultModel.self) private var model
+
   let digest: AnnumDigest
   let concertCompare: (Concert, Concert) -> Bool
   let isPathNavigable: (ArchivePath) -> Bool
@@ -43,7 +45,7 @@ struct YearDetail: View {
       .listStyle(.grouped)
     #endif
     .navigationTitle(Text(digest.annum.formatted()))
-    .toolbar { ArchiveSharableToolbarContent(item: digest) }
+    .toolbar { ArchiveSharableToolbarContent(item: digest, url: model.vault.url(for: digest)) }
   }
 }
 

--- a/Sources/Site/Music/VenueDigest+NSUserActivity.swift
+++ b/Sources/Site/Music/VenueDigest+NSUserActivity.swift
@@ -9,7 +9,7 @@ import AppIntents
 import Foundation
 
 extension VenueDigest: PathRestorableUserActivity {
-  func updateActivity(_ userActivity: NSUserActivity) {
+  func updateActivity(_ userActivity: NSUserActivity, url: URL?) {
     userActivity.isEligibleForHandoff = true
 
     userActivity.isEligibleForSearch = true
@@ -17,8 +17,8 @@ extension VenueDigest: PathRestorableUserActivity {
     userActivity.addSearchableContent(
       description: String(localized: "See Shows At This Venue"))
 
-    if let entity = VenueEntity(digest: self) {
-      userActivity.appEntityIdentifier = EntityIdentifier(for: entity)
+    if let url {
+      userActivity.appEntityIdentifier = EntityIdentifier(for: VenueEntity(digest: self, url: url))
     }
   }
 }

--- a/Tests/SiteTests/PathRestorableUserActivityTests.swift
+++ b/Tests/SiteTests/PathRestorableUserActivityTests.swift
@@ -18,9 +18,8 @@ struct PathRestorableUserActivityTests {
 
     let concert = Concert(
       show: Show(artists: [], date: PartialDate(), id: "sh17", venue: "v0"),
-      venue: Venue(id: "v0", location: Location(city: "c", state: "s"), name: "V0"), artists: [],
-      url: URL(string: "https://hey")!)
-    userActivity.update(concert)
+      venue: Venue(id: "v0", location: Location(city: "c", state: "s"), name: "V0"), artists: [])
+    userActivity.update(concert, url: rootURL)
 
     #expect(userActivity.isEligibleForHandoff)
 
@@ -30,7 +29,7 @@ struct PathRestorableUserActivityTests {
     #expect(userActivity.contentAttributeSet != nil)
 
     #expect(userActivity.isEligibleForPublicIndexing)
-    #expect(userActivity.webpageURL != nil)
+    #expect(userActivity.webpageURL == rootURL)
 
     #expect(try ArchivePath("sh-sh17") == userActivity.archivePath)
 
@@ -42,9 +41,9 @@ struct PathRestorableUserActivityTests {
 
     let artist = Artist(id: "ar0", name: "AR0")
     let digest = ArtistDigest(
-      artist: artist, url: artist.archivePath.url(using: rootURL), concerts: [], related: [],
+      artist: artist, concerts: [], related: [],
       firstSet: .empty, spanRank: .empty, showRank: .empty, venueRank: .empty)
-    userActivity.update(digest)
+    userActivity.update(digest, url: rootURL)
 
     #expect(userActivity.isEligibleForHandoff)
 
@@ -54,7 +53,7 @@ struct PathRestorableUserActivityTests {
     #expect(userActivity.contentAttributeSet != nil)
 
     #expect(userActivity.isEligibleForPublicIndexing)
-    #expect(userActivity.webpageURL != nil)
+    #expect(userActivity.webpageURL == rootURL)
 
     #expect(try ArchivePath("ar-ar0") == userActivity.archivePath)
   }
@@ -64,9 +63,9 @@ struct PathRestorableUserActivityTests {
 
     let venue = Venue(id: "v10", location: Location(city: "c", state: "s"), name: "V10")
     let digest = VenueDigest(
-      venue: venue, url: venue.archivePath.url(using: rootURL), concerts: [], related: [],
+      venue: venue, concerts: [], related: [],
       firstSet: .empty, spanRank: .empty, showRank: .empty, venueArtistRank: .empty)
-    userActivity.update(digest)
+    userActivity.update(digest, url: rootURL)
 
     #expect(userActivity.isEligibleForHandoff)
 
@@ -76,7 +75,7 @@ struct PathRestorableUserActivityTests {
     #expect(userActivity.contentAttributeSet != nil)
 
     #expect(userActivity.isEligibleForPublicIndexing)
-    #expect(userActivity.webpageURL != nil)
+    #expect(userActivity.webpageURL == rootURL)
 
     #expect(try ArchivePath("v-v10") == userActivity.archivePath)
   }
@@ -86,10 +85,10 @@ struct PathRestorableUserActivityTests {
 
     let item = Annum.year(1990)
     let digest = AnnumDigest(
-      annum: item, url: item.archivePath.url(using: rootURL), concerts: [], showRank: .empty,
+      annum: item, concerts: [], showRank: .empty,
       venueRank: .empty, artistRank: .empty)
 
-    userActivity.update(digest)
+    userActivity.update(digest, url: rootURL)
 
     #expect(userActivity.isEligibleForHandoff)
 
@@ -99,7 +98,7 @@ struct PathRestorableUserActivityTests {
     #expect(userActivity.contentAttributeSet != nil)
 
     #expect(userActivity.isEligibleForPublicIndexing)
-    #expect(userActivity.webpageURL != nil)
+    #expect(userActivity.webpageURL == rootURL)
 
     #expect(try ArchivePath("y-1990") == userActivity.archivePath)
   }
@@ -109,13 +108,12 @@ struct PathRestorableUserActivityTests {
 
     let concert = Concert(
       show: Show(artists: [], date: PartialDate(), id: "sh17", venue: "v0"),
-      venue: Venue(id: "v0", location: Location(city: "c", state: "s"), name: "V0"), artists: [],
-      url: URL(string: "https://hey")!)
+      venue: Venue(id: "v0", location: Location(city: "c", state: "s"), name: "V0"), artists: [])
 
-    userActivity.update(concert)
+    userActivity.update(concert, url: rootURL)
 
     #expect(userActivity.isEligibleForPublicIndexing)
-    #expect(userActivity.webpageURL != nil)
+    #expect(userActivity.webpageURL == rootURL)
   }
 
   @Test func decodeError_noUserInfo() {


### PR DESCRIPTION
- so instead of building and tracking the URL for everything at start up, create the URLs when an item needed to be shared.