### PR TITLE
nearby concerts uses concertMap

### DIFF
--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -221,7 +221,7 @@ enum LocationAuthorization {
   private func concerts(nearby location: CLLocation, distanceThreshold: CLLocationDistance)
     -> [Concert]
   {
-    return vault.concerts
+    vault.concertMap.values
       .filter { $0.venue != nil }
       .filter { venueLocatables[$0.venue!.id] != nil }
       .filter {


### PR DESCRIPTION
- the result is sorted, so the fact the values are not in order are not relevant.