### PR TITLE
RankingList now sorts items via a compare within a Section

### DIFF
--- a/Sources/Site/Music/UI/ArtistList.swift
+++ b/Sources/Site/Music/UI/ArtistList.swift
@@ -10,13 +10,14 @@ import SwiftUI
 struct ArtistList: View {
   let artistDigests: [ArtistDigest]
   let sectioner: LibrarySectioner
+  let compare: (ArtistDigest, ArtistDigest) -> Bool
   let sort: RankingSort
   @Binding var searchString: String
 
   var body: some View {
     let digests = artistDigests.names(filteredBy: searchString)
     RankableSortList(
-      items: digests, sectioner: sectioner,
+      items: digests, sectioner: sectioner, compare: compare,
       title: ArchiveCategory.artists.localizedString,
       associatedRankSectionHeader: { $0.venuesCountView },
       itemLabelView: { Text($0.name.emphasizedAttributed(matching: searchString)) }, sort: sort
@@ -28,15 +29,22 @@ struct ArtistList: View {
   }
 }
 
+extension ArtistList {
+  fileprivate init(model: VaultModel, sort: RankingSort, searchString: Binding<String>) {
+    self.init(
+      artistDigests: Array(model.vault.artistDigestMap.values.shuffled()),
+      sectioner: model.vault.sectioner,
+      compare: model.vault.comparator.libraryCompare(lhs:rhs:),
+      sort: sort, searchString: searchString)
+  }
+}
+
 #Preview("alphabetical", traits: .vaultModel) {
   @Previewable @Environment(VaultModel.self) var model
   @Previewable @State var searchString = ""
 
   NavigationStack {
-    ArtistList(
-      artistDigests: model.vault.artistDigests, sectioner: model.vault.sectioner,
-      sort: .alphabetical, searchString: $searchString
-    )
+    ArtistList(model: model, sort: .alphabetical, searchString: $searchString)
   }
 }
 
@@ -45,10 +53,7 @@ struct ArtistList: View {
   @Previewable @State var searchString = ""
 
   NavigationStack {
-    ArtistList(
-      artistDigests: model.vault.artistDigests, sectioner: model.vault.sectioner,
-      sort: .showCount, searchString: $searchString
-    )
+    ArtistList(model: model, sort: .showCount, searchString: $searchString)
   }
 }
 
@@ -57,10 +62,7 @@ struct ArtistList: View {
   @Previewable @State var searchString = ""
 
   NavigationStack {
-    ArtistList(
-      artistDigests: model.vault.artistDigests, sectioner: model.vault.sectioner,
-      sort: .showYearRange, searchString: $searchString
-    )
+    ArtistList(model: model, sort: .showYearRange, searchString: $searchString)
   }
 }
 
@@ -69,10 +71,7 @@ struct ArtistList: View {
   @Previewable @State var searchString = ""
 
   NavigationStack {
-    ArtistList(
-      artistDigests: model.vault.artistDigests, sectioner: model.vault.sectioner,
-      sort: .associatedRank, searchString: $searchString
-    )
+    ArtistList(model: model, sort: .associatedRank, searchString: $searchString)
   }
 }
 
@@ -81,9 +80,6 @@ struct ArtistList: View {
   @Previewable @State var searchString = ""
 
   NavigationStack {
-    ArtistList(
-      artistDigests: model.vault.artistDigests, sectioner: model.vault.sectioner,
-      sort: .firstSeen, searchString: $searchString
-    )
+    ArtistList(model: model, sort: .firstSeen, searchString: $searchString)
   }
 }

--- a/Sources/Site/Music/UI/ArtistsSummary.swift
+++ b/Sources/Site/Music/UI/ArtistsSummary.swift
@@ -18,7 +18,8 @@ struct ArtistsSummary: View {
   var body: some View {
     let artistDigests = model.filteredArtistDigests(nearbyModel, distanceThreshold: nearbyDistance)
     ArtistList(
-      artistDigests: artistDigests, sectioner: model.vault.sectioner, sort: sort,
+      artistDigests: artistDigests, sectioner: model.vault.sectioner,
+      compare: model.vault.comparator.libraryCompare(lhs:rhs:), sort: sort,
       searchString: $searchString
     )
     .nearbyLocation(filteredDataIsEmpty: artistDigests.isEmpty)

--- a/Sources/Site/Music/UI/VenueList.swift
+++ b/Sources/Site/Music/UI/VenueList.swift
@@ -10,13 +10,14 @@ import SwiftUI
 struct VenueList: View {
   let venueDigests: [VenueDigest]
   let sectioner: LibrarySectioner
+  let compare: (VenueDigest, VenueDigest) -> Bool
   let sort: RankingSort
   @Binding var searchString: String
 
   var body: some View {
     let digests = venueDigests.names(filteredBy: searchString)
     RankableSortList(
-      items: digests, sectioner: sectioner,
+      items: digests, sectioner: sectioner, compare: compare,
       title: ArchiveCategory.venues.localizedString,
       associatedRankSectionHeader: { $0.artistsCountView },
       itemLabelView: { Text($0.name.emphasizedAttributed(matching: searchString)) }, sort: sort
@@ -28,15 +29,22 @@ struct VenueList: View {
   }
 }
 
+extension VenueList {
+  fileprivate init(model: VaultModel, sort: RankingSort, searchString: Binding<String>) {
+    self.init(
+      venueDigests: Array(model.vault.venueDigestMap.values.shuffled()),
+      sectioner: model.vault.sectioner,
+      compare: model.vault.comparator.libraryCompare(lhs:rhs:),
+      sort: sort, searchString: searchString)
+  }
+}
+
 #Preview("alphabetical", traits: .vaultModel) {
   @Previewable @Environment(VaultModel.self) var model
   @Previewable @State var searchString = ""
 
   NavigationStack {
-    VenueList(
-      venueDigests: model.vault.venueDigests, sectioner: model.vault.sectioner,
-      sort: .alphabetical, searchString: $searchString
-    )
+    VenueList(model: model, sort: .alphabetical, searchString: $searchString)
   }
 }
 
@@ -45,10 +53,7 @@ struct VenueList: View {
   @Previewable @State var searchString = ""
 
   NavigationStack {
-    VenueList(
-      venueDigests: model.vault.venueDigests, sectioner: model.vault.sectioner,
-      sort: .showCount, searchString: $searchString
-    )
+    VenueList(model: model, sort: .showCount, searchString: $searchString)
   }
 }
 
@@ -57,10 +62,7 @@ struct VenueList: View {
   @Previewable @State var searchString = ""
 
   NavigationStack {
-    VenueList(
-      venueDigests: model.vault.venueDigests, sectioner: model.vault.sectioner,
-      sort: .showYearRange, searchString: $searchString
-    )
+    VenueList(model: model, sort: .showYearRange, searchString: $searchString)
   }
 }
 
@@ -69,10 +71,7 @@ struct VenueList: View {
   @Previewable @State var searchString = ""
 
   NavigationStack {
-    VenueList(
-      venueDigests: model.vault.venueDigests, sectioner: model.vault.sectioner,
-      sort: .associatedRank, searchString: $searchString
-    )
+    VenueList(model: model, sort: .associatedRank, searchString: $searchString)
   }
 }
 
@@ -81,9 +80,6 @@ struct VenueList: View {
   @Previewable @State var searchString = ""
 
   NavigationStack {
-    VenueList(
-      venueDigests: model.vault.venueDigests, sectioner: model.vault.sectioner,
-      sort: .firstSeen, searchString: $searchString
-    )
+    VenueList(model: model, sort: .firstSeen, searchString: $searchString)
   }
 }

--- a/Sources/Site/Music/UI/VenuesSummary.swift
+++ b/Sources/Site/Music/UI/VenuesSummary.swift
@@ -18,7 +18,8 @@ struct VenuesSummary: View {
   var body: some View {
     let venueDigests = model.filteredVenueDigests(nearbyModel, distanceThreshold: nearbyDistance)
     VenueList(
-      venueDigests: venueDigests, sectioner: model.vault.sectioner, sort: sort,
+      venueDigests: venueDigests, sectioner: model.vault.sectioner,
+      compare: model.vault.comparator.libraryCompare(lhs:rhs:), sort: sort,
       searchString: $searchString
     )
     .nearbyLocation(filteredDataIsEmpty: venueDigests.isEmpty)


### PR DESCRIPTION
- This way it will show valid data, regardless of input.
- Use .shuffled() and the map's values to ensure the input is not in order, but still renders as expected.
- Add fileprivate convenience initializers for previews for ArtistList and VenueList to reduce duplicate code.