### PR TITLE
Add Signpost

### DIFF
--- a/SiteApp.xcodeproj/xcshareddata/xcschemes/SiteApp.xcscheme
+++ b/SiteApp.xcodeproj/xcshareddata/xcschemes/SiteApp.xcscheme
@@ -93,7 +93,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
+      debugDocumentVersioning = "NO">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Sources/MusicData/Bracket.swift
+++ b/Sources/MusicData/Bracket.swift
@@ -36,6 +36,9 @@ struct Bracket: Codable, Sendable {
   let venueFirstSetsMap: [Venue.ID: FirstSet]
 
   public init(music: Music) async {
+    var signpost = Signpost(category: "bracket", name: "process")
+    signpost.start()
+
     async let librarySortTokenMap = music.librarySortTokenMap
     async let artistRanks = music.artistRankings
     async let venueRanks = music.venueRankings

--- a/Sources/MusicData/Lookup.swift
+++ b/Sources/MusicData/Lookup.swift
@@ -23,6 +23,9 @@ public struct Lookup: Sendable {
   private let relationMap: [String: [String]]  // Artist/Venue ID : [Artist/Venue ID]
 
   public init(music: Music) async {
+    var signpost = Signpost(category: "lookup", name: "process")
+    signpost.start()
+
     async let artistLookup = createLookup(music.artists)
     async let venueLookup = createLookup(music.venues)
     async let bracket = await Bracket(music: music)

--- a/Sources/MusicData/Vault.swift
+++ b/Sources/MusicData/Vault.swift
@@ -86,6 +86,9 @@ public struct Vault: Sendable {
   private let concertDayMap: [Int: [Concert.ID]]
 
   public init(music: Music, url: URL) async {
+    var signpost = Signpost(category: "vault", name: "process")
+    signpost.start()
+
     async let asyncLookup = await Lookup(music: music)
     let lookup = await asyncLookup
     async let asyncComparator = LibraryComparator(tokenMap: lookup.librarySortTokenMap)

--- a/Sources/Utilities/Signpost.swift
+++ b/Sources/Utilities/Signpost.swift
@@ -1,0 +1,30 @@
+//
+//  Signpost.swift
+//  SiteApp
+//
+//  Created by Greg Bolsinga on 1/19/26.
+//
+
+import Foundation
+import os
+
+struct Signpost: ~Copyable {
+  let signPost: OSSignposter
+  let name: StaticString
+  var state: OSSignpostIntervalState?
+
+  init(category: String, name: StaticString) {
+    self.signPost = OSSignposter(
+      subsystem: Bundle.main.bundleIdentifier ?? "unknown", category: category)
+    self.name = name
+  }
+
+  deinit {
+    guard let state else { return }
+    self.signPost.endInterval(name, state)
+  }
+
+  mutating func start() {
+    state = signPost.beginInterval(name)
+  }
+}


### PR DESCRIPTION
- Uses OSSignposter to measure the time for the scope of the code.
- measure creating Vault, Lookup, Bracket.
- profiling also does not set the "Document Versions" launch option. Weird default!