### PR TITLE
Add RankedArchiveItem

### DIFF
--- a/Sources/Site/Music/RankedArchiveItem.swift
+++ b/Sources/Site/Music/RankedArchiveItem.swift
@@ -1,0 +1,61 @@
+//
+//  RankedArchiveItem.swift
+//  SiteApp
+//
+//  Created by Greg Bolsinga on 2/1/26.
+//
+
+import Foundation
+
+struct RankedArchiveItem: Rankable {
+  let archivePath: ArchivePath
+  let id: String
+  let sortname: String?
+  let name: String
+  private let rank: RankDigest
+
+  internal init(
+    archivePath: ArchivePath, id: String, sortname: String?, name: String, rank: RankDigest
+  ) {
+    self.archivePath = archivePath
+    self.id = id
+    self.sortname = sortname
+    self.name = name
+    self.rank = rank
+  }
+
+  var firstSet: FirstSet { rank.firstSet }
+
+  var showRank: Ranking { rank.showRank }
+
+  func ranking(for sort: RankingSort) -> Ranking {
+    switch sort {
+    case .alphabetical, .firstSeen:
+      Ranking.empty
+    case .showCount:
+      rank.showRank
+    case .showYearRange:
+      rank.spanRank
+    case .associatedRank:
+      rank.associatedRank
+    }
+  }
+}
+
+extension Rankable where ID == String {
+  func rankedArchiveItem(_ rank: RankDigest) -> RankedArchiveItem {
+    RankedArchiveItem(archivePath: archivePath, id: id, sortname: sortname, name: name, rank: rank)
+  }
+}
+
+extension ArtistDigest {
+  var rankedArchiveItem: RankedArchiveItem {
+    rankedArchiveItem(rank)
+  }
+}
+
+extension VenueDigest {
+  var rankedArchiveItem: RankedArchiveItem {
+    rankedArchiveItem(rank)
+  }
+}

--- a/Sources/Site/Music/UI/ArtistsSummary.swift
+++ b/Sources/Site/Music/UI/ArtistsSummary.swift
@@ -16,14 +16,14 @@ struct ArtistsSummary: View {
   @Binding var searchString: String
 
   var body: some View {
-    let artistDigests = model.filteredArtistDigests(nearbyModel, distanceThreshold: nearbyDistance)
+    let artists = model.nearbyArtists(nearbyModel, distanceThreshold: nearbyDistance)
     ArtistList(
-      artists: artistDigests, sectioner: model.vault.sectioner,
+      artists: artists, sectioner: model.vault.sectioner,
       compare: model.vault.comparator.libraryCompare(lhs:rhs:),
       filter: { $0.names(filteredBy: $1) }, sort: sort,
       searchString: $searchString
     )
-    .nearbyLocation(filteredDataIsEmpty: artistDigests.isEmpty)
+    .nearbyLocation(filteredDataIsEmpty: artists.isEmpty)
   }
 }
 

--- a/Sources/Site/Music/UI/VenuesSummary.swift
+++ b/Sources/Site/Music/UI/VenuesSummary.swift
@@ -16,14 +16,14 @@ struct VenuesSummary: View {
   @Binding var searchString: String
 
   var body: some View {
-    let venueDigests = model.filteredVenueDigests(nearbyModel, distanceThreshold: nearbyDistance)
+    let venues = model.nearbyVenues(nearbyModel, distanceThreshold: nearbyDistance)
     VenueList(
-      venues: venueDigests, sectioner: model.vault.sectioner,
+      venues: venues, sectioner: model.vault.sectioner,
       compare: model.vault.comparator.libraryCompare(lhs:rhs:),
       filter: { $0.names(filteredBy: $1) }, sort: sort,
       searchString: $searchString
     )
-    .nearbyLocation(filteredDataIsEmpty: venueDigests.isEmpty)
+    .nearbyLocation(filteredDataIsEmpty: venues.isEmpty)
   }
 }
 

--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -187,15 +187,19 @@ enum LocationAuthorization {
     return nearbyConcerts
   }
 
-  private func venueDigestsNearby(_ distanceThreshold: CLLocationDistance) -> [VenueDigest] {
+  private func venuesNearby(_ distanceThreshold: CLLocationDistance)
+    -> any Collection<RankedArchiveItem>
+  {
     let nearbyVenueIDs = Set(concertsNearby(distanceThreshold).compactMap { $0.venue?.id })
-    return nearbyVenueIDs.compactMap { vault.venueDigestMap[$0] }
+    return nearbyVenueIDs.compactMap { vault.venueDigestMap[$0] }.map { $0.rankedArchiveItem }
   }
 
-  private func artistDigestsNearby(_ distanceThreshold: CLLocationDistance) -> [ArtistDigest] {
+  private func artistsNearby(_ distanceThreshold: CLLocationDistance)
+    -> any Collection<RankedArchiveItem>
+  {
     let nearbyArtistIDs = Set(
       concertsNearby(distanceThreshold).flatMap { $0.artists.map { $0.id } })
-    return nearbyArtistIDs.compactMap { vault.artistDigestMap[$0] }
+    return nearbyArtistIDs.compactMap { vault.artistDigestMap[$0] }.map { $0.rankedArchiveItem }
   }
 
   private func decadesMapsNearby(_ distanceThreshold: CLLocationDistance) -> [Decade: [Annum: Set<
@@ -237,18 +241,18 @@ enum LocationAuthorization {
     nearbyModel.locationFilter.isNearby ? decadesMapsNearby(distanceThreshold) : vault.decadesMap
   }
 
-  func filteredVenueDigests(_ nearbyModel: NearbyModel, distanceThreshold: CLLocationDistance)
-    -> any Collection<VenueDigest>
+  func nearbyVenues(_ nearbyModel: NearbyModel, distanceThreshold: CLLocationDistance)
+    -> any Collection<RankedArchiveItem>
   {
     nearbyModel.locationFilter.isNearby
-      ? venueDigestsNearby(distanceThreshold) : vault.venueDigestMap.values
+      ? venuesNearby(distanceThreshold) : vault.venueDigestMap.values.map { $0.rankedArchiveItem }
   }
 
-  func filteredArtistDigests(_ nearbyModel: NearbyModel, distanceThreshold: CLLocationDistance)
-    -> any Collection<ArtistDigest>
+  func nearbyArtists(_ nearbyModel: NearbyModel, distanceThreshold: CLLocationDistance)
+    -> any Collection<RankedArchiveItem>
   {
     nearbyModel.locationFilter.isNearby
-      ? artistDigestsNearby(distanceThreshold) : vault.artistDigestMap.values
+      ? artistsNearby(distanceThreshold) : vault.artistDigestMap.values.map { $0.rankedArchiveItem }
   }
 
   @MainActor


### PR DESCRIPTION
- It can be created from a Artist or Venue Digest.
- The long term idea is to remove the need for Digests, since they have circular references if they were persisted to a cache.