### PR TITLE
RankableSortList does not require Identifiable.ID to be a string.

### DIFF
--- a/Sources/MusicData/LibrarySectioner+Music.swift
+++ b/Sources/MusicData/LibrarySectioner+Music.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension LibrarySectioner {
-  public init(librarySortTokenMap: [String: String]) async {
+  public init(librarySortTokenMap: [Key: String]) async {
     async let sectionMap = librarySortTokenMap.mapValues { $0.librarySection }
     self.init(sectionMap: await sectionMap)
   }

--- a/Sources/MusicData/Vault.swift
+++ b/Sources/MusicData/Vault.swift
@@ -62,7 +62,7 @@ extension Venue {
 
 public struct Vault: Sendable {
   public let comparator: LibraryComparator
-  public let sectioner: LibrarySectioner
+  public let sectioner: LibrarySectioner<String>
   public let rootURL: URL
   public let concertMap: [Concert.ID: Concert]
 
@@ -84,7 +84,8 @@ public struct Vault: Sendable {
     async let asyncLookup = await Lookup(music: music)
     let lookup = await asyncLookup
     async let asyncComparator = LibraryComparator(tokenMap: lookup.librarySortTokenMap)
-    async let sectioner = await LibrarySectioner(librarySortTokenMap: lookup.librarySortTokenMap)
+    async let sectioner = await LibrarySectioner<String>(
+      librarySortTokenMap: lookup.librarySortTokenMap)
 
     let comparator = await asyncComparator
 

--- a/Sources/Site/Music/UI/ArtistList.swift
+++ b/Sources/Site/Music/UI/ArtistList.swift
@@ -7,9 +7,9 @@
 
 import SwiftUI
 
-struct ArtistList<A>: View where A: Rankable, A.ID == String {
+struct ArtistList<A>: View where A: Rankable {
   let artists: any Collection<A>
-  let sectioner: LibrarySectioner
+  let sectioner: LibrarySectioner<A.ID>
   let compare: (A, A) -> Bool
   let filter: (any Collection<A>, String) -> [A]
   let sort: RankingSort

--- a/Sources/Site/Music/UI/RankableSearchableSortList.swift
+++ b/Sources/Site/Music/UI/RankableSearchableSortList.swift
@@ -7,10 +7,9 @@
 
 import SwiftUI
 
-struct RankableSearchableSortList<A, SectionHeaderContent: View>: View
-where A: Rankable, A.ID == String {
+struct RankableSearchableSortList<A, SectionHeaderContent: View>: View where A: Rankable {
   let items: any Collection<A>
-  let sectioner: LibrarySectioner
+  let sectioner: LibrarySectioner<A.ID>
   let compare: (A, A) -> Bool
   let filter: (any Collection<A>, String) -> [A]
   let sort: RankingSort

--- a/Sources/Site/Music/UI/RankableSortList.swift
+++ b/Sources/Site/Music/UI/RankableSortList.swift
@@ -7,10 +7,9 @@
 
 import SwiftUI
 
-struct RankableSortList<T, SectionHeaderContent: View, LabelContent: View>: View
-where T: Rankable, T.ID == String {
+struct RankableSortList<T, SectionHeaderContent: View, LabelContent: View>: View where T: Rankable {
   let items: [T]
-  let sectioner: LibrarySectioner
+  let sectioner: LibrarySectioner<T.ID>
   let compare: (T, T) -> Bool
   let title: String
   @ViewBuilder let associatedRankSectionHeader: (Ranking) -> SectionHeaderContent

--- a/Sources/Site/Music/UI/VenueList.swift
+++ b/Sources/Site/Music/UI/VenueList.swift
@@ -7,9 +7,9 @@
 
 import SwiftUI
 
-struct VenueList<V>: View where V: Rankable, V.ID == String {
+struct VenueList<V>: View where V: Rankable {
   let venues: any Collection<V>
-  let sectioner: LibrarySectioner
+  let sectioner: LibrarySectioner<V.ID>
   let compare: (V, V) -> Bool
   let filter: (any Collection<V>, String) -> [V]
   let sort: RankingSort

--- a/Sources/Utilities/LibraryComparable.swift
+++ b/Sources/Utilities/LibraryComparable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol LibraryComparable: Identifiable {
+public protocol LibraryComparable: Identifiable where ID: Codable, ID: Sendable {
   var sortname: String? { get }
   var name: String { get }
 }

--- a/Sources/Utilities/LibrarySectioner.swift
+++ b/Sources/Utilities/LibrarySectioner.swift
@@ -12,18 +12,19 @@ extension Logger {
   fileprivate static let librarySectioner = Logger(category: "librarySectioner")
 }
 
-public struct LibrarySectioner: Codable, Sendable {
-  private let sectionMap: [String: LibrarySection]
+public struct LibrarySectioner<Key>: Codable, Sendable
+where Key: Codable, Key: Hashable, Key: Sendable {
+  private let sectionMap: [Key: LibrarySection]
 
-  public init(sectionMap: [String: LibrarySection] = [:]) {
+  public init(sectionMap: [Key: LibrarySection] = [:]) {
     self.sectionMap = sectionMap
   }
 
   private func librarySection<T>(_ item: T) -> LibrarySection
-  where T: LibraryComparable, T.ID == String {
+  where T: LibraryComparable, T.ID == Key {
     sectionMap[item.id]
       ?? {
-        Logger.librarySectioner.debug("\(item.id, privacy: .public) not in map.")
+        Logger.librarySectioner.debug("\(String(describing:item.id), privacy: .public) not in map.")
         return item.librarySortString.librarySection
       }()
   }
@@ -31,7 +32,7 @@ public struct LibrarySectioner: Codable, Sendable {
 
 extension LibrarySectioner {
   public func sectionMap<T>(for items: [T]) -> [LibrarySection: [T]]
-  where T: LibraryComparable, T.ID == String {
+  where T: LibraryComparable, T.ID == Key {
     items.reduce(into: [LibrarySection: [T]]()) {
       let section = self.librarySection($1)
       var arr = ($0[section] ?? [])


### PR DESCRIPTION
- need to get here by making LibrarySectioner generic.
- this was done because ArchivePath cannot be used as Identifiable.ID... **yet**.
- Note: Vault still creates LibrarySectioner<String>, but it doesn't have to. That will be addressed in future diffs.