### PR TITLE
Tracker now has generic ID and AnnumID

### DIFF
--- a/Sources/MusicData/Bracket.swift
+++ b/Sources/MusicData/Bracket.swift
@@ -33,12 +33,16 @@ struct Bracket: Codable, Sendable {
     signpost.start()
 
     async let librarySortTokenMap = music.librarySortTokenMap
-    async let tracker = music.tracker
+    async let tracker = music.tracker(
+      venueIdentifier: { $0 },
+      artistIdentifier: { $0 },
+      showIdentifier: { $0 },
+      annumIdentifier: { $0.annum })
 
     self.artistRankDigestMap = await tracker.artistRankDigests()
     self.venueRankDigestMap = await tracker.venueRankDigests()
     self.annumRankDigestMap = await tracker.annumRankDigests()
-    self.decadesMap = await tracker.decadesMap()
+    self.decadesMap = await tracker.decadesMap(decade: { $0.decade })
     self.concertDayMap = await tracker.dayOfLeapYearShows
 
     self.librarySortTokenMap = await librarySortTokenMap

--- a/Sources/MusicData/Music+Ranking.swift
+++ b/Sources/MusicData/Music+Ranking.swift
@@ -8,8 +8,18 @@
 import Foundation
 
 extension Music {
-  var tracker: Tracker {
-    Tracker(shows: self.shows)
+  func tracker<ID, AnnumID>(
+    venueIdentifier: @Sendable (_ venue: String) -> ID,
+    artistIdentifier: @Sendable (_ artist: String) -> ID,
+    showIdentifier: @Sendable (_ artist: String) -> ID,
+    annumIdentifier: @Sendable (_ annum: PartialDate) -> AnnumID
+  ) -> Tracker<ID, AnnumID> {
+    Tracker(
+      shows: self.shows,
+      venueIdentifier: venueIdentifier,
+      artistIdentifier: artistIdentifier,
+      showIdentifier: showIdentifier,
+      annumIdentifier: annumIdentifier)
   }
 
   var relationMap: [String: [String]] {


### PR DESCRIPTION
- This is preparation for migrating things to using `ArchivePath` for `Identifiable`.
- This is odd with closures for the identifiers. Will next spend time to figure out how to get a protocol with associatedTypes to match the generics in here.