### PR TITLE
Bracket now has generic ID and AnnumID

### DIFF
--- a/Sources/MusicData/Lookup.swift
+++ b/Sources/MusicData/Lookup.swift
@@ -19,7 +19,7 @@ private func createLookup<T: Identifiable>(_ sequence: [T]) -> [T.ID: T] {
 public struct Lookup: Sendable {
   private let artistMap: [Artist.ID: Artist]
   private let venueMap: [Venue.ID: Venue]
-  private let bracket: Bracket
+  private let bracket: Bracket<String, Annum>
   private let relationMap: [String: [String]]  // Artist/Venue ID : [Artist/Venue ID]
 
   public init(music: Music) async {
@@ -28,7 +28,13 @@ public struct Lookup: Sendable {
 
     async let artistLookup = createLookup(music.artists)
     async let venueLookup = createLookup(music.venues)
-    async let bracket = await Bracket(music: music)
+    async let bracket = await Bracket(
+      music: music,
+      venueIdentifier: { $0 },
+      artistIdentifier: { $0 },
+      showIdentifier: { $0 },
+      annumIdentifier: { $0.annum },
+      decadeIdentifier: { $0.decade })
     async let relations = music.relationMap
 
     self.artistMap = await artistLookup

--- a/Sources/site_tool/RootURLArguments+Bracket.swift
+++ b/Sources/site_tool/RootURLArguments+Bracket.swift
@@ -8,7 +8,16 @@
 import Foundation
 
 extension RootURLArguments {
-  func bracket() async throws -> Bracket {
-    await Bracket(music: try await music().showsOnly)
+  func bracket() async throws -> Bracket<ArchivePath, ArchivePath> {
+    await Bracket(
+      music: try await music().showsOnly,
+      venueIdentifier: { ArchivePath.venue($0) },
+      artistIdentifier: { ArchivePath.artist($0) },
+      showIdentifier: { ArchivePath.show($0) },
+      annumIdentifier: { ArchivePath.year($0.annum) },
+      decadeIdentifier: {
+        guard case .year(let year) = $0 else { return .unknown }
+        return year.decade
+      })
   }
 }


### PR DESCRIPTION
- This is preparation for migrating things to using `ArchivePath` for `Identifiable`.
- `DumpBracketCommand` flexes and creates `Bracket<ArchivePath, ArchivePath>` for proof of concept!