### PR TITLE
Add ArchiveIdentifier protocol

### DIFF
--- a/Sources/MusicData/ArchiveIdentifier.swift
+++ b/Sources/MusicData/ArchiveIdentifier.swift
@@ -1,0 +1,19 @@
+//
+//  ArchiveIdentifier.swift
+//  SiteApp
+//
+//  Created by Greg Bolsinga on 2/5/26.
+//
+
+import Foundation
+
+public protocol ArchiveIdentifier: Sendable {
+  associatedtype ID: Codable, Hashable, Sendable
+  associatedtype AnnumID: Codable, Hashable, Sendable
+
+  func venue(_ id: String) -> ID
+  func artist(_ id: String) -> ID
+  func show(_ id: String) -> ID
+  func annum(_ date: PartialDate) -> AnnumID
+  func decade(_ annum: AnnumID) -> Decade
+}

--- a/Sources/MusicData/ArchivePathIdentifier.swift
+++ b/Sources/MusicData/ArchivePathIdentifier.swift
@@ -1,0 +1,19 @@
+//
+//  ArchivePathIdentifier.swift
+//  SiteApp
+//
+//  Created by Greg Bolsinga on 2/5/26.
+//
+
+import Foundation
+
+struct ArchivePathIdentifier: ArchiveIdentifier {
+  func venue(_ id: String) -> ArchivePath { ArchivePath.venue(id) }
+  func artist(_ id: String) -> ArchivePath { ArchivePath.artist(id) }
+  func show(_ id: String) -> ArchivePath { ArchivePath.show(id) }
+  func annum(_ date: PartialDate) -> ArchivePath { ArchivePath.year(date.annum) }
+  func decade(_ annum: ArchivePath) -> Decade {
+    guard case .year(let year) = annum else { return .unknown }
+    return year.decade
+  }
+}

--- a/Sources/MusicData/BasicIdentifier.swift
+++ b/Sources/MusicData/BasicIdentifier.swift
@@ -1,0 +1,16 @@
+//
+//  BasicIdentifier.swift
+//  SiteApp
+//
+//  Created by Greg Bolsinga on 2/5/26.
+//
+
+import Foundation
+
+struct BasicIdentifier: ArchiveIdentifier {
+  func venue(_ id: String) -> String { id }
+  func artist(_ id: String) -> String { id }
+  func show(_ id: String) -> String { id }
+  func annum(_ date: PartialDate) -> Annum { date.annum }
+  func decade(_ annum: Annum) -> Decade { annum.decade }
+}

--- a/Sources/MusicData/Bracket.swift
+++ b/Sources/MusicData/Bracket.swift
@@ -20,11 +20,10 @@ extension Music {
   }
 }
 
-struct Bracket<ID, AnnumID>: Codable, Sendable
-where
-  ID: Codable, ID: Hashable, ID: Sendable,
-  AnnumID: Codable, AnnumID: Hashable, AnnumID: Sendable
-{
+struct Bracket<Identifier: ArchiveIdentifier>: Codable, Sendable {
+  typealias ID = Identifier.ID
+  typealias AnnumID = Identifier.AnnumID
+
   let librarySortTokenMap: [String: String]  // String ID : tokenized LibraryComparable name for fast sorting.
   let artistRankDigestMap: [ID: RankDigest]
   let venueRankDigestMap: [ID: RankDigest]
@@ -32,29 +31,18 @@ where
   let decadesMap: [Decade: [AnnumID: Set<ID>]]
   let concertDayMap: [Int: Set<ID>]
 
-  init(
-    music: Music,
-    venueIdentifier: @Sendable (_ venue: String) -> ID,
-    artistIdentifier: @Sendable (_ artist: String) -> ID,
-    showIdentifier: @Sendable (_ artist: String) -> ID,
-    annumIdentifier: @Sendable (_ annum: PartialDate) -> AnnumID,
-    decadeIdentifier: @Sendable (AnnumID) -> Decade
-  ) async {
+  init(music: Music, identifier: Identifier) async {
     var signpost = Signpost(category: "bracket", name: "process")
     signpost.start()
 
     async let librarySortTokenMap = music.librarySortTokenMap
 
-    async let tracker = music.tracker(
-      venueIdentifier: venueIdentifier,
-      artistIdentifier: artistIdentifier,
-      showIdentifier: showIdentifier,
-      annumIdentifier: annumIdentifier)
+    async let tracker = music.tracker(identifier: identifier)
 
     self.artistRankDigestMap = await tracker.artistRankDigests()
     self.venueRankDigestMap = await tracker.venueRankDigests()
     self.annumRankDigestMap = await tracker.annumRankDigests()
-    self.decadesMap = await tracker.decadesMap(decade: decadeIdentifier)
+    self.decadesMap = await tracker.decadesMap(decade: { identifier.decade($0) })
     self.concertDayMap = await tracker.dayOfLeapYearShows
 
     self.librarySortTokenMap = await librarySortTokenMap

--- a/Sources/MusicData/Music+Ranking.swift
+++ b/Sources/MusicData/Music+Ranking.swift
@@ -8,18 +8,8 @@
 import Foundation
 
 extension Music {
-  func tracker<ID, AnnumID>(
-    venueIdentifier: @Sendable (_ venue: String) -> ID,
-    artistIdentifier: @Sendable (_ artist: String) -> ID,
-    showIdentifier: @Sendable (_ artist: String) -> ID,
-    annumIdentifier: @Sendable (_ annum: PartialDate) -> AnnumID
-  ) -> Tracker<ID, AnnumID> {
-    Tracker(
-      shows: self.shows,
-      venueIdentifier: venueIdentifier,
-      artistIdentifier: artistIdentifier,
-      showIdentifier: showIdentifier,
-      annumIdentifier: annumIdentifier)
+  func tracker<Identifier: ArchiveIdentifier>(identifier: Identifier) -> Tracker<Identifier> {
+    Tracker(shows: self.shows, identifier: identifier)
   }
 
   var relationMap: [String: [String]] {

--- a/Sources/MusicData/Vault.swift
+++ b/Sources/MusicData/Vault.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 extension Annum {
-  fileprivate func digest(sortedConcerts: [Concert], lookup: Lookup<String, Annum>) -> AnnumDigest {
+  fileprivate func digest(sortedConcerts: [Concert], lookup: Lookup<BasicIdentifier>) -> AnnumDigest
+  {
     AnnumDigest(
       annum: self,
       shows: sortedConcerts.compactMap {
@@ -21,7 +22,8 @@ extension Annum {
 }
 
 extension Artist {
-  fileprivate func digest(sortedConcerts: [Concert], lookup: Lookup<String, Annum>) -> ArtistDigest
+  fileprivate func digest(sortedConcerts: [Concert], lookup: Lookup<BasicIdentifier>)
+    -> ArtistDigest
   {
     ArtistDigest(
       artist: self,
@@ -43,13 +45,14 @@ extension Concert {
 }
 
 extension Show {
-  fileprivate func concert(lookup: Lookup<String, Annum>) -> Concert {
+  fileprivate func concert(lookup: Lookup<BasicIdentifier>) -> Concert {
     Concert(show: self, venue: lookup.venueForShow(self), artists: lookup.artistsForShow(self))
   }
 }
 
 extension Venue {
-  fileprivate func digest(sortedConcerts: [Concert], lookup: Lookup<String, Annum>) -> VenueDigest {
+  fileprivate func digest(sortedConcerts: [Concert], lookup: Lookup<BasicIdentifier>) -> VenueDigest
+  {
     VenueDigest(
       venue: self,
       shows: sortedConcerts.compactMap {
@@ -82,13 +85,7 @@ public struct Vault: Sendable {
     var signpost = Signpost(category: "vault", name: "process")
     signpost.start()
 
-    async let asyncLookup = await Lookup<String, Annum>(
-      music: music,
-      venueIdentifier: { $0 },
-      artistIdentifier: { $0 },
-      showIdentifier: { $0 },
-      annumIdentifier: { $0.annum },
-      decadeIdentifier: { $0.decade })
+    async let asyncLookup = await Lookup(music: music, identifier: BasicIdentifier())
     let lookup = await asyncLookup
     async let asyncComparator = LibraryComparator(tokenMap: lookup.librarySortTokenMap)
     async let sectioner = await LibrarySectioner<String>(

--- a/Sources/site_tool/DumpBracketCommand.swift
+++ b/Sources/site_tool/DumpBracketCommand.swift
@@ -9,7 +9,7 @@ import ArgumentParser
 import Foundation
 
 private struct OrderedBracket: Encodable {
-  let bracket: Bracket<ArchivePath, ArchivePath>
+  let bracket: Bracket<ArchivePathIdentifier>
 
   private enum Keys: String, CodingKey {
     case librarySortTokenMap

--- a/Sources/site_tool/RootURLArguments+Bracket.swift
+++ b/Sources/site_tool/RootURLArguments+Bracket.swift
@@ -8,16 +8,7 @@
 import Foundation
 
 extension RootURLArguments {
-  func bracket() async throws -> Bracket<ArchivePath, ArchivePath> {
-    await Bracket(
-      music: try await music().showsOnly,
-      venueIdentifier: { ArchivePath.venue($0) },
-      artistIdentifier: { ArchivePath.artist($0) },
-      showIdentifier: { ArchivePath.show($0) },
-      annumIdentifier: { ArchivePath.year($0.annum) },
-      decadeIdentifier: {
-        guard case .year(let year) = $0 else { return .unknown }
-        return year.decade
-      })
+  func bracket() async throws -> Bracket<ArchivePathIdentifier> {
+    await Bracket(music: try await music().showsOnly, identifier: ArchivePathIdentifier())
   }
 }


### PR DESCRIPTION
- Pass it through `Lookup`, `Bracker`, `Tracker`
- Simplifies interfaces.
- Add `BasicIdentifier` that identifies types as they are now.
- Add `ArchivePathIdentifier` that identifies  as `ArchivePath` for the future!