### PR TITLE
LibraryComparator now has a generic ID

### DIFF
--- a/Sources/MusicData/Bracket.swift
+++ b/Sources/MusicData/Bracket.swift
@@ -8,14 +8,16 @@
 import Foundation
 
 extension Music {
-  fileprivate var librarySortTokenMap: [String: String] {
+  fileprivate func librarySortTokenMap<Identifier: ArchiveIdentifier>(_ identifier: Identifier)
+    -> [Identifier.ID: String]
+  {
     let tokenizer = LibraryCompareTokenizer()
     return artists.reduce(
       into: venues.reduce(into: [:]) {
-        $0[$1.id] = tokenizer.removeCommonInitialPunctuation($1.librarySortString)
+        $0[identifier.venue($1.id)] = tokenizer.removeCommonInitialPunctuation($1.librarySortString)
       }
     ) {
-      $0[$1.id] = tokenizer.removeCommonInitialPunctuation($1.librarySortString)
+      $0[identifier.artist($1.id)] = tokenizer.removeCommonInitialPunctuation($1.librarySortString)
     }
   }
 }
@@ -24,7 +26,7 @@ struct Bracket<Identifier: ArchiveIdentifier>: Codable, Sendable {
   typealias ID = Identifier.ID
   typealias AnnumID = Identifier.AnnumID
 
-  let librarySortTokenMap: [String: String]  // String ID : tokenized LibraryComparable name for fast sorting.
+  let librarySortTokenMap: [ID: String]  // ID : tokenized LibraryComparable name for fast sorting.
   let artistRankDigestMap: [ID: RankDigest]
   let venueRankDigestMap: [ID: RankDigest]
   let annumRankDigestMap: [AnnumID: RankDigest]
@@ -35,7 +37,7 @@ struct Bracket<Identifier: ArchiveIdentifier>: Codable, Sendable {
     var signpost = Signpost(category: "bracket", name: "process")
     signpost.start()
 
-    async let librarySortTokenMap = music.librarySortTokenMap
+    async let librarySortTokenMap = music.librarySortTokenMap(identifier)
 
     async let tracker = music.tracker(identifier: identifier)
 

--- a/Sources/MusicData/LibraryComparator+Concert.swift
+++ b/Sources/MusicData/LibraryComparator+Concert.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-extension LibraryComparator {
+extension LibraryComparator where ID == String {
   public func compare(lhs: Concert, rhs: Concert) -> Bool {
     let lhShow = lhs.show
     let rhShow = rhs.show

--- a/Sources/MusicData/Lookup.swift
+++ b/Sources/MusicData/Lookup.swift
@@ -40,7 +40,7 @@ public struct Lookup<Identifier: ArchiveIdentifier>: Sendable {
     self.relationMap = await relations
   }
 
-  var librarySortTokenMap: [String: String] {
+  var librarySortTokenMap: [ID: String] {
     bracket.librarySortTokenMap
   }
 

--- a/Sources/MusicData/Vault.swift
+++ b/Sources/MusicData/Vault.swift
@@ -65,7 +65,7 @@ extension Venue {
 }
 
 public struct Vault: Sendable {
-  public let comparator: LibraryComparator
+  public let comparator: LibraryComparator<String>
   public let sectioner: LibrarySectioner<String>
   public let rootURL: URL
   public let concertMap: [Concert.ID: Concert]

--- a/Sources/Utilities/LibraryComparator.swift
+++ b/Sources/Utilities/LibraryComparator.swift
@@ -12,24 +12,27 @@ extension Logger {
   fileprivate static let libraryComparator = Logger(category: "libraryComparator")
 }
 
-public struct LibraryComparator: Codable, Sendable {
-  private let tokenMap: [String: String]
+public struct LibraryComparator<ID>: Codable, Sendable
+where ID: Codable, ID: Hashable, ID: Sendable {
+  private let tokenMap: [ID: String]
 
-  public init(tokenMap: [String: String] = [:]) {
+  public init(tokenMap: [ID: String] = [:]) {
     self.tokenMap = tokenMap
   }
 
-  public func libraryCompare<T>(lhs: T, rhs: T) -> Bool where T: LibraryComparable, T.ID == String {
+  public func libraryCompare<T>(lhs: T, rhs: T) -> Bool where T: LibraryComparable, T.ID == ID {
     let lhToken =
       tokenMap[lhs.id]
       ?? {
-        Logger.libraryComparator.debug("\(lhs.id, privacy: .public) not in map.")
+        Logger.libraryComparator.debug(
+          "\(String(describing: lhs.id), privacy: .public) not in map.")
         return LibraryCompareTokenizer().removeCommonInitialPunctuation(lhs.librarySortString)
       }()
     let rhToken =
       tokenMap[rhs.id]
       ?? {
-        Logger.libraryComparator.debug("\(rhs.id, privacy: .public) not in map.")
+        Logger.libraryComparator.debug(
+          "\(String(describing: rhs.id), privacy: .public) not in map.")
         return LibraryCompareTokenizer().removeCommonInitialPunctuation(rhs.librarySortString)
       }()
     return libraryCompareTokens(lhs: lhToken, rhs: rhToken)

--- a/Tests/UtilitiesTests/LibraryComparatorTests.swift
+++ b/Tests/UtilitiesTests/LibraryComparatorTests.swift
@@ -23,7 +23,7 @@ extension String {
 }
 
 struct LibraryComparatorTests {
-  let comparator = LibraryComparator()
+  let comparator = LibraryComparator<String>()
 
   @Test func stringBasic() {
     #expect(comparator.libraryCompare(lhs: "A", rhs: "B"))


### PR DESCRIPTION
- This will allow it to be something other than `String` in the future.