### PR TITLE
Vault now uses BasicIdentifier types

### DIFF
--- a/Sources/MusicData/ArchiveIdentifier.swift
+++ b/Sources/MusicData/ArchiveIdentifier.swift
@@ -16,5 +16,6 @@ public protocol ArchiveIdentifier: Codable, Sendable {
   func show(_ id: String) throws -> ID
   func annum(_ annum: Annum) throws -> AnnumID
   func decade(_ annum: AnnumID) -> Decade
+  func annum(for annum: AnnumID) -> Annum
   func relation(_ id: String) throws -> ID
 }

--- a/Sources/MusicData/ArchivePathIdentifier.swift
+++ b/Sources/MusicData/ArchivePathIdentifier.swift
@@ -12,9 +12,12 @@ struct ArchivePathIdentifier: ArchiveIdentifier {
   func artist(_ id: String) throws -> ArchivePath { try ArchivePath(raw: id) }
   func show(_ id: String) throws -> ArchivePath { try ArchivePath(raw: id) }
   func annum(_ annum: Annum) throws -> ArchivePath { ArchivePath.year(annum) }
-  func decade(_ annum: ArchivePath) -> Decade {
-    guard case .year(let year) = annum else { return .unknown }
-    return year.decade
+  func decade(_ id: ArchivePath) -> Decade {
+    annum(for: id).decade
+  }
+  func annum(for id: ArchivePath) -> Annum {
+    guard case .year(let annum) = id else { return .unknown }
+    return annum
   }
   func relation(_ id: String) throws -> ArchivePath { try ArchivePath(raw: id) }
 }

--- a/Sources/MusicData/BasicIdentifier.swift
+++ b/Sources/MusicData/BasicIdentifier.swift
@@ -7,11 +7,14 @@
 
 import Foundation
 
-struct BasicIdentifier: ArchiveIdentifier {
-  func venue(_ id: String) throws -> String { id }
-  func artist(_ id: String) throws -> String { id }
-  func show(_ id: String) throws -> String { id }
-  func annum(_ annum: Annum) throws -> Annum { annum }
-  func decade(_ annum: Annum) -> Decade { annum.decade }
-  func relation(_ id: String) throws -> String { id }
+public struct BasicIdentifier: ArchiveIdentifier {
+  public init() {}
+
+  public func venue(_ id: String) throws -> String { id }
+  public func artist(_ id: String) throws -> String { id }
+  public func show(_ id: String) throws -> String { id }
+  public func annum(_ annum: Annum) throws -> Annum { annum }
+  public func decade(_ annum: Annum) -> Decade { annum.decade }
+  public func annum(for id: Annum) -> Annum { id }
+  public func relation(_ id: String) throws -> String { id }
 }


### PR DESCRIPTION
- It cannot be generic yet, since `Artist`, `Venue`, `Show` and `Concert` still have IDs that are `String`. 
-- These are passed around and then there are compiler errors where it says "This means `Identifier.ID` must be `String`".
- More generifying to come!