### PR TITLE
Make ArchivePathIdentifier public

### DIFF
--- a/Sources/MusicData/ArchivePathIdentifier.swift
+++ b/Sources/MusicData/ArchivePathIdentifier.swift
@@ -7,17 +7,18 @@
 
 import Foundation
 
-struct ArchivePathIdentifier: ArchiveIdentifier {
-  func venue(_ id: String) throws -> ArchivePath { try ArchivePath(raw: id) }
-  func artist(_ id: String) throws -> ArchivePath { try ArchivePath(raw: id) }
-  func show(_ id: String) throws -> ArchivePath { try ArchivePath(raw: id) }
-  func annum(_ annum: Annum) throws -> ArchivePath { ArchivePath.year(annum) }
-  func decade(_ id: ArchivePath) -> Decade {
+public struct ArchivePathIdentifier: ArchiveIdentifier {
+  public init() {}
+  public func venue(_ id: String) throws -> ArchivePath { try ArchivePath(raw: id) }
+  public func artist(_ id: String) throws -> ArchivePath { try ArchivePath(raw: id) }
+  public func show(_ id: String) throws -> ArchivePath { try ArchivePath(raw: id) }
+  public func annum(_ annum: Annum) throws -> ArchivePath { ArchivePath.year(annum) }
+  public func decade(_ id: ArchivePath) -> Decade {
     annum(for: id).decade
   }
-  func annum(for id: ArchivePath) -> Annum {
+  public func annum(for id: ArchivePath) -> Annum {
     guard case .year(let annum) = id else { return .unknown }
     return annum
   }
-  func relation(_ id: String) throws -> ArchivePath { try ArchivePath(raw: id) }
+  public func relation(_ id: String) throws -> ArchivePath { try ArchivePath(raw: id) }
 }


### PR DESCRIPTION
- This will allow it to be used in the public `Vault` when things are ready.