### PR TITLE
DumpVault can use ArchivePathIdentifier

### DIFF
--- a/SiteApp.xcodeproj/xcshareddata/xcschemes/SiteApp.xcscheme
+++ b/SiteApp.xcodeproj/xcshareddata/xcschemes/SiteApp.xcscheme
@@ -63,6 +63,14 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
+            argument = "dumpVault"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--string"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "dumpDiary"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/Sources/MusicData/LibraryComparable+ArchivePath.swift
+++ b/Sources/MusicData/LibraryComparable+ArchivePath.swift
@@ -1,0 +1,16 @@
+//
+//  LibraryComparable+ArchivePath.swift
+//  SiteApp
+//
+//  Created by Greg Bolsinga on 2/14/26.
+//
+
+import Foundation
+
+extension LibraryComparator where ID == ArchivePath {
+  public func libraryCompare<Comparable: LibraryComparable & PathRestorable>(
+    lhs: Comparable, rhs: Comparable
+  ) -> Bool where Comparable.ID == String {
+    libraryCompare(lhs: lhs, lhsID: lhs.archivePath, rhs: rhs, rhsID: rhs.archivePath)
+  }
+}

--- a/Sources/MusicData/LibraryComparator+Concert.swift
+++ b/Sources/MusicData/LibraryComparator+Concert.swift
@@ -27,3 +27,24 @@ extension LibraryComparator where ID == String {
     return lhShow.date < rhShow.date
   }
 }
+
+extension LibraryComparator where ID == ArchivePath {
+  public func compare(lhs: Concert, rhs: Concert) -> Bool {
+    let lhShow = lhs.show
+    let rhShow = rhs.show
+    if lhShow.date == rhShow.date {
+      if let lhVenue = lhs.venue, let rhVenue = rhs.venue {
+        if lhVenue == rhVenue {
+          if let lhHeadliner = lhs.artists.first, let rhHeadliner = rhs.artists.first {
+            if lhHeadliner == rhHeadliner {
+              return lhs.id < rhs.id
+            }
+            return libraryCompare(lhs: lhHeadliner, rhs: rhHeadliner)
+          }
+        }
+        return libraryCompare(lhs: lhVenue, rhs: rhVenue)
+      }
+    }
+    return lhShow.date < rhShow.date
+  }
+}


### PR DESCRIPTION
This is all interesting to learn. If generics are specialized for the two types I know the ID could be (String or ArchivePath), everything along the way must know that ID type. So despite the code as written being the same, it's different. I'm sure I'm missing something here, but this is what I will do for the transition.
 One part that makes sense here is the LibraryComparable+ArchivePath code.