### PR TITLE
Specialize Vault.concerts(on:)

### DIFF
--- a/Sources/Intents/EntityQuery+ConcertsToday.swift
+++ b/Sources/Intents/EntityQuery+ConcertsToday.swift
@@ -9,7 +9,14 @@ import AppIntents
 import Foundation
 
 extension EntityQuery {
-  func concertsToday<Identifier: ArchiveIdentifier>(_ vault: Vault<Identifier>) -> [Concert] {
+  func concertsToday(_ vault: Vault<BasicIdentifier>) -> [Concert] {
+    // This is running outside the scope of VaultModel, so reference `Date.now` directly.
+    vault.concerts(on: Date.now.dayOfLeapYear)
+  }
+}
+
+extension EntityQuery {
+  func concertsToday(_ vault: Vault<ArchivePathIdentifier>) -> [Concert] {
     // This is running outside the scope of VaultModel, so reference `Date.now` directly.
     vault.concerts(on: Date.now.dayOfLeapYear)
   }

--- a/Sources/site_tool/DumpVaultCommand.swift
+++ b/Sources/site_tool/DumpVaultCommand.swift
@@ -60,7 +60,7 @@ struct DumpVaultCommand: AsyncParsableCommand {
   var identifier: IdentifierFlag = .archivePath
 
   @Option(help: "Search String to use.")
-  var searchString : String?
+  var searchString: String?
 
   private func dump(
     concerts: [Concert],


### PR DESCRIPTION
- This way `Vault.identifier` may be removed.