### PR TITLE
Reference Lookup to create the Digests/Concerts

### DIFF
--- a/Sources/MusicData/Bracket.swift
+++ b/Sources/MusicData/Bracket.swift
@@ -34,6 +34,7 @@ struct Bracket<Identifier: ArchiveIdentifier>: Codable, Sendable {
   let annumRankDigestMap: [AnnumID: RankDigest]
   let decadesMap: [Decade: [AnnumID: Set<ID>]]
   let concertDayMap: [Int: Set<ID>]
+  let showMap: [ID: Show]
 
   init(music: Music, identifier: Identifier) async throws {
     var signpost = Signpost(category: "bracket", name: "process")
@@ -48,6 +49,7 @@ struct Bracket<Identifier: ArchiveIdentifier>: Codable, Sendable {
     self.annumRankDigestMap = try await tracker.annumRankDigests()
     self.decadesMap = try await tracker.decadesMap(decade: { identifier.decade($0) })
     self.concertDayMap = try await tracker.dayOfLeapYearShows
+    self.showMap = try await tracker.showMap
 
     self.librarySortTokenMap = try await librarySortTokenMap
   }

--- a/Sources/MusicData/Lookup.swift
+++ b/Sources/MusicData/Lookup.swift
@@ -17,8 +17,8 @@ public struct Lookup<Identifier: ArchiveIdentifier>: Codable, Sendable {
   public typealias AnnumID = Identifier.AnnumID
 
   private let identifier: Identifier
-  private let artistMap: [ID: Artist]
-  private let venueMap: [ID: Venue]
+  let artistMap: [ID: Artist]
+  let venueMap: [ID: Venue]
   private let bracket: Bracket<Identifier>
   private let relationMap: [ID: Set<ID>]  // Artist/Venue ID : Set<Artist/Venue ID>
 
@@ -50,6 +50,10 @@ public struct Lookup<Identifier: ArchiveIdentifier>: Codable, Sendable {
 
   public var concertDayMap: [Int: Set<ID>] {
     bracket.concertDayMap
+  }
+
+  public var showMap: [ID: Show] {
+    bracket.showMap
   }
 
   public func venueForShow(_ show: Show) -> Venue? {

--- a/Sources/MusicData/Tracker.swift
+++ b/Sources/MusicData/Tracker.swift
@@ -52,9 +52,11 @@ struct Tracker<Identifier: ArchiveIdentifier> {
   var annumVenues = [AnnumID: Set<ID>]()
 
   var dayOfLeapYearShows = [Int: Set<ID>]()
+  var showMap = [ID: Show]()
 
   private mutating func track(show: Show, identifier: Identifier) throws {
     let showID = try identifier.show(show.id)
+    showMap[showID] = show
 
     let venueID = try identifier.venue(show.venue)
     venueSpanDates.insert(key: venueID, value: show.date)

--- a/Sources/MusicData/Vault.swift
+++ b/Sources/MusicData/Vault.swift
@@ -72,13 +72,13 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
     let lookup = try await asyncLookup
     let comparator = LibraryComparator(tokenMap: lookup.librarySortTokenMap)
 
-    async let asyncSortedConcerts = music.shows.map {
+    async let asyncSortedConcerts = lookup.showMap.values.map {
       Concert(show: $0, venue: lookup.venueForShow($0), artists: lookup.artistsForShow($0))
     }.sorted(by: { Self.sort(lhs: $0, rhs: $1, identifier: identifier, comparator: comparator) })
 
     let sortedConcerts = await asyncSortedConcerts
 
-    async let artistDigests = music.artists.map { artist in
+    async let artistDigests = lookup.artistMap.values.map { artist in
       ArtistDigest(
         artist: artist,
         shows: sortedConcerts.compactMap {
@@ -89,7 +89,7 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
         rank: lookup.rankDigest(artist: try identifier.artist(artist.id)))
     }
 
-    async let venueDigests = music.venues.map { venue in
+    async let venueDigests = lookup.venueMap.values.map { venue in
       VenueDigest(
         venue: venue,
         shows: sortedConcerts.compactMap {


### PR DESCRIPTION
- Lookup now tracks [ID: Show] and then Vault uses this data to build the Digests/Concerts.
- The outcome of this is that Vault depends upon Lookup, not Music. More to come.