### PR TITLE
Build Digests differently.

### DIFF
--- a/Sources/MusicData/Lookup+Concert.swift
+++ b/Sources/MusicData/Lookup+Concert.swift
@@ -34,41 +34,71 @@ extension Lookup {
     return showIDs.compactMap { showDigest(showId: $0) }
   }
 
-  var concerts: [Concert] {
-    showMap.values.compactMap {
-      guard let venue = venueForShow($0) else { return nil }
-      return Concert(show: $0, venue: venue, artists: artistsForShow($0))
-    }
+  fileprivate func concert(show: Show) -> Concert? {
+    guard let venue = venueForShow(show) else { return nil }
+    return Concert(show: show, venue: venue, artists: artistsForShow(show))
   }
 
-  func artistDigestMap(concerts: [Concert]) throws -> [ID: ArtistDigest] {
+  func concert(showId: ID) -> Concert? {
+    guard let show = showMap[showId] else { return nil }
+    return concert(show: show)
+  }
+
+  var concerts: [Concert] {
+    // Used to build concertMap
+    showMap.values.compactMap { concert(show: $0) }
+  }
+
+  func artistDigestMap() throws -> [ID: ArtistDigest] {
     try artistMap.values.map { artist in
-      ArtistDigest(
-        artist: artist,
-        shows: concerts.compactMap {
-          guard $0.show.artists.contains(artist.id) else { return nil }
-          return $0.digest
-        },
-        related: related(artist).sorted(by: { $0.name < $1.name }),
-        rank: rankDigest(artist: try identifier.artist(artist.id)))
+      try artistDigest(artist: artist)
     }.reduce(into: [:]) {
       $0[try identifier.artist($1.artist.id)] = $1
     }
   }
 
-  func venueDigestMap(concerts: [Concert]) throws -> [ID: VenueDigest] {
+  private func artistDigest(artist: Artist, artistID: ID) throws -> ArtistDigest {
+    ArtistDigest(
+      artist: artist,
+      shows: shows(artistID: artistID).compactMap { showDigest(showId: $0) },
+      related: related(artist).sorted(by: { $0.name < $1.name }),
+      rank: rankDigest(artist: artistID))
+  }
+
+  private func artistDigest(artist: Artist) throws -> ArtistDigest {
+    let artistID = try identifier.artist(artist.id)
+    return try artistDigest(artist: artist, artistID: artistID)
+  }
+
+  func artistDigest(id artistID: ID) -> ArtistDigest? {
+    guard let artist = artistMap[artistID] else { return nil }
+    return try? artistDigest(artist: artist, artistID: artistID)
+  }
+
+  func venueDigestMap() throws -> [ID: VenueDigest] {
     try venueMap.values.map { venue in
-      VenueDigest(
-        venue: venue,
-        shows: concerts.compactMap {
-          guard $0.show.venue == venue.id else { return nil }
-          return $0.digest
-        },
-        related: related(venue).sorted(by: { $0.name < $1.name }),
-        rank: rankDigest(venue: try identifier.venue(venue.id)))
+      try venueDigest(venue: venue)
     }.reduce(into: [:]) {
       $0[try identifier.venue($1.venue.id)] = $1
     }
+  }
+
+  private func venueDigest(venue: Venue, venueID: ID) throws -> VenueDigest {
+    VenueDigest(
+      venue: venue,
+      shows: shows(venueID: venueID).compactMap { showDigest(showId: $0) },
+      related: related(venue).sorted(by: { $0.name < $1.name }),
+      rank: rankDigest(venue: venueID))
+  }
+
+  private func venueDigest(venue: Venue) throws -> VenueDigest {
+    let venueID = try identifier.venue(venue.id)
+    return try venueDigest(venue: venue, venueID: venueID)
+  }
+
+  func venueDigest(id venueID: ID) -> VenueDigest? {
+    guard let venue = venueMap[venueID] else { return nil }
+    return try? venueDigest(venue: venue, venueID: venueID)
   }
 
   func annumDigest(annum: Annum) throws -> AnnumDigest {

--- a/Sources/MusicData/Vault.swift
+++ b/Sources/MusicData/Vault.swift
@@ -33,17 +33,15 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
     self.lookup = lookup
     let comparator = LibraryComparator(tokenMap: lookup.librarySortTokenMap)
 
-    let concerts = lookup.concerts
+    async let artistDigestMap = lookup.artistDigestMap()
 
-    async let artistDigestMap = lookup.artistDigestMap(concerts: concerts)
-
-    async let venueDigestMap = lookup.venueDigestMap(concerts: concerts)
+    async let venueDigestMap = lookup.venueDigestMap()
 
     self.comparator = comparator
     self.sectioner = await LibrarySectioner(librarySortTokenMap: lookup.librarySortTokenMap)
     self.rootURL = url
 
-    self.concertMap = try concerts.reduce(into: [:]) { $0[try identifier.show($1.id)] = $1 }
+    self.concertMap = try lookup.concerts.reduce(into: [:]) { $0[try identifier.show($1.id)] = $1 }
 
     self.artistDigestMap = try await artistDigestMap
 
@@ -57,11 +55,6 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
 
   var decadesMap: [Decade: [AnnumID: Set<ID>]] {
     lookup.decadesMap
-  }
-
-  fileprivate func unsortedConcerts(on dayOfLeapYear: Int) -> any Collection<Concert> {
-    let concertIDs = lookup.concertDayMap[dayOfLeapYear] ?? []
-    return concertIDs.compactMap { concertMap[$0] }
   }
 
   /// The URL for this category.
@@ -79,7 +72,9 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
   }
 
   func concerts(on dayOfLeapYear: Int) -> [Concert] {
-    unsortedConcerts(on: dayOfLeapYear).sorted(by: compare(lhs:rhs:))
+    // dayOfLeapYear: ShowID
+    lookup.concertDayMap[dayOfLeapYear]?.compactMap { lookup.concert(showId: $0) }.sorted(
+      by: compare(lhs:rhs:)) ?? []
   }
 
   func compare(lhs: Concert, rhs: Concert) -> Bool {
@@ -106,6 +101,18 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
     try? lookup.annumDigest(annum: annum)
   }
 
+  func digest(artist: ID) -> ArtistDigest? {
+    lookup.artistDigest(id: artist)
+  }
+
+  func digest(venue: ID) -> VenueDigest? {
+    lookup.venueDigest(id: venue)
+  }
+
+  func concert(show: ID) -> Concert? {
+    lookup.concert(showId: show)
+  }
+
   func venues() -> [Venue] {
     Array(lookup.venueMap.values)
   }
@@ -116,6 +123,10 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
 
   func shows() -> [Show] {
     Array(lookup.showMap.values)
+  }
+
+  func showIDs() -> Set<ID> {
+    Set(lookup.showMap.keys)
   }
 
   func artists(venueID: ID) -> Set<ID> {

--- a/Sources/Site/Music/UI/VaultPreviewModifier.swift
+++ b/Sources/Site/Music/UI/VaultPreviewModifier.swift
@@ -32,22 +32,22 @@ extension PreviewTrait where T == Preview.ViewTraits {
 
 extension VaultModel {
   func previewArtist(_ id: String) -> ArtistDigest {
-    vault.artistDigestMap[id]!
+    vault.digest(artist: id)!
   }
 
   var previewAllArtists: any Collection<ArtistDigest> {
-    vault.artistDigestMap.values.shuffled()
+    vault.artists().compactMap { vault.digest(artist: $0.id) }.shuffled()
   }
 
   func previewVenue(_ id: String) -> VenueDigest {
-    vault.venueDigestMap[id]!
+    vault.digest(venue: id)!
   }
 
   var previewAllVenues: any Collection<VenueDigest> {
-    vault.venueDigestMap.values.shuffled()
+    vault.venues().compactMap { vault.digest(venue: $0.id) }.shuffled()
   }
 
   func previewConcert(_ id: String) -> Concert {
-    vault.concertMap[id]!
+    vault.concert(show: id)!
   }
 }

--- a/Sources/site_tool/DumpVaultCommand.swift
+++ b/Sources/site_tool/DumpVaultCommand.swift
@@ -10,13 +10,13 @@ import Foundation
 
 extension Vault {
   fileprivate func concertsForArtist(artistID: ID) -> any Collection<Concert> {
-    self.shows(artistID: artistID).compactMap { concertMap[$0] }
+    self.shows(artistID: artistID).compactMap { concert(show: $0) }
   }
 
   fileprivate func dump(
     searchString: String?, concertsForArtist: (Artist) -> any Collection<Concert>
   ) {
-    let concerts = concertMap.values.sorted(by: compare(lhs:rhs:))
+    let concerts = showIDs().compactMap { concert(show: $0) }.sorted(by: compare(lhs:rhs:))
     let artists = artists().sorted(by: compare(lhs:rhs:))
     let venues = venues().sorted(by: compare(lhs:rhs:))
 

--- a/Tests/SiteTests/ConcertComparatorTests.swift
+++ b/Tests/SiteTests/ConcertComparatorTests.swift
@@ -38,8 +38,8 @@ struct ConcertComparatorTests {
     let vaultTest = try await createVault(
       artists: [artist1, artist2], shows: [show1, show2], venues: [venue1, venue2])
 
-    let concert1 = vaultTest.concertMap[show1.id]!
-    let concert2 = vaultTest.concertMap[show2.id]!
+    let concert1 = vaultTest.concert(show: show1.id)!
+    let concert2 = vaultTest.concert(show: show2.id)!
 
     #expect(concert1 != concert2)
     #expect(vaultTest.compare(lhs: concert1, rhs: concert2))
@@ -53,8 +53,8 @@ struct ConcertComparatorTests {
     let vaultTest = try await createVault(
       artists: [artist1, artist2], shows: [show1, show2], venues: [venue1, venue2])
 
-    let concert1 = vaultTest.concertMap[show1.id]!
-    let concert2 = vaultTest.concertMap[show2.id]!
+    let concert1 = vaultTest.concert(show: show1.id)!
+    let concert2 = vaultTest.concert(show: show2.id)!
 
     #expect(concert1 != concert2)
     #expect(!vaultTest.compare(lhs: concert1, rhs: concert2))
@@ -68,8 +68,8 @@ struct ConcertComparatorTests {
     let vaultTest = try await createVault(
       artists: [artist1, artist2], shows: [show1, show2], venues: [venue1, venue2])
 
-    let concert1 = vaultTest.concertMap[show1.id]!
-    let concert2 = vaultTest.concertMap[show2.id]!
+    let concert1 = vaultTest.concert(show: show1.id)!
+    let concert2 = vaultTest.concert(show: show2.id)!
 
     #expect(concert1 != concert2)
     #expect(vaultTest.compare(lhs: concert1, rhs: concert2))
@@ -83,8 +83,8 @@ struct ConcertComparatorTests {
     let vaultTest = try await createVault(
       artists: [artist1, artist2], shows: [show1, show2], venues: [venue1, venue2])
 
-    let concert1 = vaultTest.concertMap[show1.id]!
-    let concert2 = vaultTest.concertMap[show2.id]!
+    let concert1 = vaultTest.concert(show: show1.id)!
+    let concert2 = vaultTest.concert(show: show2.id)!
 
     #expect(concert1 != concert2)
     #expect(vaultTest.compare(lhs: concert1, rhs: concert2))
@@ -98,8 +98,8 @@ struct ConcertComparatorTests {
     let vaultTest = try await createVault(
       artists: [artist1, artist2], shows: [show1, show2], venues: [venue1, venue2])
 
-    let concert1 = vaultTest.concertMap[show1.id]!
-    let concert2 = vaultTest.concertMap[show2.id]!
+    let concert1 = vaultTest.concert(show: show1.id)!
+    let concert2 = vaultTest.concert(show: show2.id)!
 
     #expect(concert1 == concert2)
     #expect(!vaultTest.compare(lhs: concert1, rhs: concert2))


### PR DESCRIPTION
- ConcertMap/ArtistDigestMap/VenueDigestMap are now all built via Lookup and not [Concert].
- Another small step towards having these be created on-demand instead of up-front.
- More work to come.