### PR TITLE
Lookup relateds via ID

### DIFF
--- a/Sources/MusicData/Lookup+Concert.swift
+++ b/Sources/MusicData/Lookup+Concert.swift
@@ -48,7 +48,7 @@ extension Lookup {
     ArtistDigest(
       artist: artist,
       shows: shows(artistID: artistID).compactMap { showDigest(showId: $0) },
-      related: related(artist).sorted(by: { $0.name < $1.name }),
+      related: related(artistID: artistID).sorted(by: { $0.name < $1.name }),
       rank: rankDigest(artist: artistID))
   }
 
@@ -61,7 +61,7 @@ extension Lookup {
     VenueDigest(
       venue: venue,
       shows: shows(venueID: venueID).compactMap { showDigest(showId: $0) },
-      related: related(venue).sorted(by: { $0.name < $1.name }),
+      related: related(venueID: venueID).sorted(by: { $0.name < $1.name }),
       rank: rankDigest(venue: venueID))
   }
 

--- a/Sources/MusicData/Lookup.swift
+++ b/Sources/MusicData/Lookup.swift
@@ -164,11 +164,10 @@ public struct Lookup<Identifier: ArchiveIdentifier>: Codable, Sendable {
   /// Relatedness is domain-specific (e.g., shared characteristics or associations) and is
   /// expressed as lightweight `Related` values suitable for UI display.
   ///
-  /// - Parameter item: The venue to find related venues for.
+  /// - Parameter venueID: The stable venue identifier.
   /// - Returns: A collection of related items.
-  public func related(_ item: Venue) -> any Collection<Related> {
-    guard let id = try? identifier.relation(item.id) else { return [] }
-    return relationMap[id]?.compactMap { venueMap[$0] }.map {
+  public func related(venueID: ID) -> any Collection<Related> {
+    relationMap[venueID]?.compactMap { venueMap[$0] }.map {
       Related(id: $0.archivePath, name: $0.name)
     } ?? []
   }
@@ -178,11 +177,10 @@ public struct Lookup<Identifier: ArchiveIdentifier>: Codable, Sendable {
   /// Relatedness is domain-specific and is expressed as lightweight `Related` values suitable
   /// for UI display.
   ///
-  /// - Parameter item: The artist to find related artists for.
+  /// - Parameter artistID: The stable artist identifier.
   /// - Returns: A collection of related items.
-  public func related(_ item: Artist) -> any Collection<Related> {
-    guard let id = try? identifier.relation(item.id) else { return [] }
-    return relationMap[id]?.compactMap { artistMap[$0] }.map {
+  public func related(artistID: ID) -> any Collection<Related> {
+    relationMap[artistID]?.compactMap { artistMap[$0] }.map {
       Related(id: $0.archivePath, name: $0.name)
     } ?? []
   }


### PR DESCRIPTION
- removes two uses of `identifier` in Lookup, which is nice!