### PR TITLE
Use the ID, Artist/Venue pairs when appropriate

### DIFF
--- a/Sources/Intents/Vault+Entities.swift
+++ b/Sources/Intents/Vault+Entities.swift
@@ -29,7 +29,7 @@ extension Vault where Identifier == BasicIdentifier {
   }
 
   var artistEntities: [ArtistEntity] {
-    artists().compactMap { artistEntity(for: $0.id) }
+    artistIDs().compactMap { artistEntity(for: $0.0) }
   }
 
   func artistEntities(filteredBy searchString: String) -> [ArtistEntity] {
@@ -37,7 +37,7 @@ extension Vault where Identifier == BasicIdentifier {
   }
 
   var venueEntities: [VenueEntity] {
-    venues().compactMap { venueEntity(for: $0.id) }
+    venueIDs().compactMap { venueEntity(for: $0.0) }
   }
 
   func venueEntities(filteredBy searchString: String) -> [VenueEntity] {

--- a/Sources/MusicData/Vault.swift
+++ b/Sources/MusicData/Vault.swift
@@ -152,16 +152,12 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
     lookup.concert(showId: show)
   }
 
-  func venues() -> [Venue] {
-    Array(lookup.venueMap.values)
-  }
-
   func venueIDs() -> [(ID, Venue)] {
     lookup.venueMap.map { ($0, $1) }
   }
 
-  func artists() -> [Artist] {
-    Array(lookup.artistMap.values)
+  func artistIDs() -> [(ID, Artist)] {
+    lookup.artistMap.map { ($0, $1) }
   }
 
   func shows() -> [Show] {

--- a/Sources/Site/Music/UI/VaultPreviewModifier.swift
+++ b/Sources/Site/Music/UI/VaultPreviewModifier.swift
@@ -36,7 +36,7 @@ extension VaultModel {
   }
 
   var previewAllArtists: any Collection<ArtistDigest> {
-    vault.artists().compactMap { vault.digest(artist: $0.id) }.shuffled()
+    vault.artistIDs().compactMap { vault.digest(artist: $0.0) }.shuffled()
   }
 
   func previewVenue(_ id: String) -> VenueDigest {
@@ -44,7 +44,7 @@ extension VaultModel {
   }
 
   var previewAllVenues: any Collection<VenueDigest> {
-    vault.venues().compactMap { vault.digest(venue: $0.id) }.shuffled()
+    vault.venueIDs().compactMap { vault.digest(venue: $0.0) }.shuffled()
   }
 
   func previewConcert(_ id: String) -> Concert {

--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -250,7 +250,8 @@ enum LocationAuthorization {
     -> any Collection<RankedArchiveItem>
   {
     nearbyModel.locationFilter.isNearby
-      ? venuesNearby(distanceThreshold) : vault.venues().compactMap { vault.rankedVenue(id: $0.id) }
+      ? venuesNearby(distanceThreshold)
+      : vault.venueIDs().compactMap { vault.rankedVenue(id: $0.0) }
   }
 
   func nearbyArtists(_ nearbyModel: NearbyModel, distanceThreshold: CLLocationDistance)
@@ -258,7 +259,7 @@ enum LocationAuthorization {
   {
     nearbyModel.locationFilter.isNearby
       ? artistsNearby(distanceThreshold)
-      : vault.artists().compactMap { vault.rankedArtist(id: $0.id) }
+      : vault.artistIDs().compactMap { vault.rankedArtist(id: $0.0) }
   }
 
   @MainActor

--- a/Sources/site_tool/DumpVaultCommand.swift
+++ b/Sources/site_tool/DumpVaultCommand.swift
@@ -17,8 +17,8 @@ extension Vault {
     searchString: String?, concertsForArtist: (Artist) -> any Collection<Concert>
   ) {
     let concerts = showIDs().compactMap { concert(show: $0) }.sorted(by: compare(lhs:rhs:))
-    let artists = artists().sorted(by: compare(lhs:rhs:))
-    let venues = venues().sorted(by: compare(lhs:rhs:))
+    let artists = artistIDs().map { $0.1 }.sorted(by: compare(lhs:rhs:))
+    let venues = venueIDs().map { $0.1 }.sorted(by: compare(lhs:rhs:))
 
     print("Artists: \(artists.count)")
     print("Shows: \(concerts.count)")

--- a/Sources/site_tool/NextIDCommand.swift
+++ b/Sources/site_tool/NextIDCommand.swift
@@ -34,12 +34,12 @@ extension Vault {
   }
 
   fileprivate var nextVenueID: Venue.ID {
-    let nextIndex = max(venues().count, 0)
+    let nextIndex = max(venueIDs().count, 0)
     return "\(ArchivePath.venuePrefix)\(nextIndex)"
   }
 
-  fileprivate var nextArtistID: Venue.ID {
-    let nextIndex = max(artists().count, 0)
+  fileprivate var nextArtistID: Artist.ID {
+    let nextIndex = max(artistIDs().count, 0)
     return "\(ArchivePath.artistPrefix)\(nextIndex)"
   }
 
@@ -48,11 +48,11 @@ extension Vault {
   }
 
   fileprivate var missingVenueIndices: any Collection<Int> {
-    venues().map { $0.id }.missingIndices(prefix: ArchivePath.venuePrefix)
+    venueIDs().map { $0.1.id }.missingIndices(prefix: ArchivePath.venuePrefix)
   }
 
   fileprivate var missingArtistIndices: any Collection<Int> {
-    artists().map { $0.id }.missingIndices(prefix: ArchivePath.artistPrefix)
+    artistIDs().map { $0.1.id }.missingIndices(prefix: ArchivePath.artistPrefix)
   }
 
   fileprivate func printIDs() {


### PR DESCRIPTION
This makes things a little more generic, in that `ID` is associated with Artist/Venue while those have IDs that may not be the same as the generic ID. Small steps!