### PR TITLE
VaultModel is now generic for Identifier.

### DIFF
--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -21,11 +21,16 @@ enum LocationAuthorization {
   case denied  // Locations denied by user.
 }
 
-@Observable public final class VaultModel {
-  public let vault: Vault<BasicIdentifier>
+public typealias VaultModel = AbstractVaultModel<BasicIdentifier>
+
+@Observable public final class AbstractVaultModel<Identifier: ArchiveIdentifier> {
+  public typealias ID = Identifier.ID
+  public typealias AnnumID = Identifier.AnnumID
+
+  public let vault: Vault<Identifier>
 
   internal var todayDayOfLeapYear: Int = Date.now.dayOfLeapYear
-  private var venueLocatables: [BasicIdentifier.ID: Locatable] = [:]
+  private var venueLocatables: [ID: Locatable] = [:]
   private var currentLocation: CLLocation?
   internal var locationAuthorization = LocationAuthorization.allowed
 
@@ -49,7 +54,7 @@ enum LocationAuthorization {
 
   @MainActor
   internal init(
-    _ vault: Vault<BasicIdentifier>,
+    _ vault: Vault<Identifier>,
     executeAsynchronousTasks: Bool,
     distanceFilter: CLLocationDistance = 10
   ) {
@@ -182,9 +187,7 @@ enum LocationAuthorization {
     }
   }
 
-  private func venueIDsNearby(_ distanceThreshold: CLLocationDistance)
-    -> any Collection<BasicIdentifier.ID>
-  {
+  private func venueIDsNearby(_ distanceThreshold: CLLocationDistance) -> any Collection<ID> {
     guard let currentLocation else {
       Logger.vaultModel.log("Nearby: No Location")
       return []
@@ -209,14 +212,14 @@ enum LocationAuthorization {
     return nearbyArtistIDs.compactMap { vault.rankedArtist(id: $0) }
   }
 
-  private func decadesMapsNearby(_ distanceThreshold: CLLocationDistance) -> [Decade: [Annum: Set<
-    Concert.ID
-  >]] {
+  private func decadesMapsNearby(_ distanceThreshold: CLLocationDistance)
+    -> [Decade: [AnnumID: Set<ID>]]
+  {
     let nearbyVenueIDs = venueIDsNearby(distanceThreshold)
     let nearbyConcertIDs = nearbyVenueIDs.flatMap { vault.shows(venueID: $0) }
-    return [Decade: [Annum: Set<Concert.ID>]](
+    return [Decade: [AnnumID: Set<ID>]](
       uniqueKeysWithValues: vault.decadesMap.compactMap {
-        let nearbyAnnums = [Annum: Set<Show.ID>](
+        let nearbyAnnums = [AnnumID: Set<ID>](
           uniqueKeysWithValues: $0.value.compactMap {
             let nearbyIDs = $0.value.filter { nearbyConcertIDs.contains($0) }
             if nearbyIDs.isEmpty {
@@ -232,7 +235,7 @@ enum LocationAuthorization {
   }
 
   private func venues(nearby location: CLLocation, distanceThreshold: CLLocationDistance)
-    -> any Collection<BasicIdentifier.ID>
+    -> any Collection<ID>
   {
     venueLocatables.compactMap { (id, locatable) in
       guard locatable.nearby(to: location, distanceThreshold: distanceThreshold) else { return nil }
@@ -241,7 +244,7 @@ enum LocationAuthorization {
   }
 
   func filteredDecadesMap(_ nearbyModel: NearbyModel, distanceThreshold: CLLocationDistance)
-    -> [Decade: [Annum: Set<Concert.ID>]]
+    -> [Decade: [AnnumID: Set<ID>]]
   {
     nearbyModel.locationFilter.isNearby ? decadesMapsNearby(distanceThreshold) : vault.decadesMap
   }

--- a/Sources/site_tool/DumpVaultCommand.swift
+++ b/Sources/site_tool/DumpVaultCommand.swift
@@ -1,5 +1,5 @@
 //
-//  Program.swift
+//  DumpVaultCommand.swift
 //  site
 //
 //  Created by Greg Bolsinga on 12/6/20.
@@ -12,13 +12,16 @@ extension Vault {
   fileprivate func concertsForArtist(artistID: ID) -> any Collection<Concert> {
     self.shows(artistID: artistID).compactMap { concert(show: $0) }
   }
+}
 
+extension AbstractVaultModel {
   fileprivate func dump(
     searchString: String?, concertsForArtist: (Artist) -> any Collection<Concert>
   ) {
-    let concerts = showIDs().compactMap { concert(show: $0) }.sorted(by: compare(lhs:rhs:))
-    let artists = artistIDs().map { $0.1 }.sorted(by: compare(lhs:rhs:))
-    let venues = venueIDs().map { $0.1 }.sorted(by: compare(lhs:rhs:))
+    let concerts = vault.showIDs().compactMap { vault.concert(show: $0) }.sorted(
+      by: vault.compare(lhs:rhs:))
+    let artists = vault.artistIDs().map { $0.1 }.sorted(by: vault.compare(lhs:rhs:))
+    let venues = vault.venueIDs().map { $0.1 }.sorted(by: vault.compare(lhs:rhs:))
 
     print("Artists: \(artists.count)")
     print("Shows: \(concerts.count)")
@@ -45,8 +48,8 @@ extension Vault {
     }
 
     if let searchString {
-      let venues = self.venues(filteredBy: searchString).map { $0.name }
-      let artists = self.artists(filteredBy: searchString).map { $0.name }
+      let venues = self.vault.venues(filteredBy: searchString).map { $0.name }
+      let artists = self.vault.artists(filteredBy: searchString).map { $0.name }
       let matches = venues + artists
       print("Matching (\(searchString)): \(matches.joined(separator: "; "))")
     }
@@ -67,16 +70,19 @@ struct DumpVaultCommand: AsyncParsableCommand {
   @Option(help: "Search String to use.")
   var searchString: String?
 
+  @MainActor
   func run() async throws {
     switch identifier {
     case .basic:
       let vault = try await rootURL.vault(identifier: BasicIdentifier())
-      vault.dump(searchString: searchString) {
+      let vaultModel = AbstractVaultModel(vault, executeAsynchronousTasks: false)
+      vaultModel.dump(searchString: searchString) {
         vault.concertsForArtist(artistID: $0.id)
       }
     case .archivePath:
       let vault = try await rootURL.vault(identifier: ArchivePathIdentifier())
-      vault.dump(searchString: searchString) {
+      let vaultModel = AbstractVaultModel(vault, executeAsynchronousTasks: false)
+      vaultModel.dump(searchString: searchString) {
         vault.concertsForArtist(artistID: $0.archivePath)
       }
     }


### PR DESCRIPTION
- Rename it to AbstractVaultModel and use a typealias for VaultModel to reduce the sheer number of changes that would be required elsewhere.
- Update DumpVaultCommand for this change.