### PR TITLE
throw if invalid compare token is used

### DIFF
--- a/Sources/App/Localizable.xcstrings
+++ b/Sources/App/Localizable.xcstrings
@@ -277,6 +277,9 @@
     "Invalid Data." : {
 
     },
+    "Invalid Token: %@." : {
+
+    },
     "Lineup" : {
 
     },

--- a/Sources/MusicData/ArchiveIdentifier.swift
+++ b/Sources/MusicData/ArchiveIdentifier.swift
@@ -24,6 +24,6 @@ public protocol ArchiveIdentifier: Codable, Sendable {
   func libraryCompare<Comparable: Identifiable & LibraryComparable & PathRestorable>(
     lhs: Comparable,
     rhs: Comparable,
-    comparator: (Comparable, ID, Comparable, ID) -> Bool
-  ) -> Bool where Comparable.ID == String
+    comparator: (Comparable, ID, Comparable, ID) throws -> Bool
+  ) throws -> Bool where Comparable.ID == String
 }

--- a/Sources/MusicData/ArchivePathIdentifier.swift
+++ b/Sources/MusicData/ArchivePathIdentifier.swift
@@ -31,8 +31,8 @@ public struct ArchivePathIdentifier: ArchiveIdentifier {
   public func libraryCompare<Comparable: Identifiable & LibraryComparable & PathRestorable>(
     lhs: Comparable,
     rhs: Comparable,
-    comparator: (Comparable, ID, Comparable, ID) -> Bool
-  ) -> Bool where Comparable.ID == String {
-    comparator(lhs, lhs.archivePath, rhs, rhs.archivePath)
+    comparator: (Comparable, ID, Comparable, ID) throws -> Bool
+  ) throws -> Bool where Comparable.ID == String {
+    try comparator(lhs, lhs.archivePath, rhs, rhs.archivePath)
   }
 }

--- a/Sources/MusicData/BasicIdentifier.swift
+++ b/Sources/MusicData/BasicIdentifier.swift
@@ -28,8 +28,8 @@ public struct BasicIdentifier: ArchiveIdentifier {
   public func libraryCompare<Comparable: Identifiable & LibraryComparable & PathRestorable>(
     lhs: Comparable,
     rhs: Comparable,
-    comparator: (Comparable, ID, Comparable, ID) -> Bool
-  ) -> Bool where Comparable.ID == String {
-    comparator(lhs, lhs.id, rhs, rhs.id)
+    comparator: (Comparable, ID, Comparable, ID) throws -> Bool
+  ) throws -> Bool where Comparable.ID == String {
+    try comparator(lhs, lhs.id, rhs, rhs.id)
   }
 }

--- a/Sources/MusicData/Bracket.swift
+++ b/Sources/MusicData/Bracket.swift
@@ -13,6 +13,17 @@ extension Logger {
   fileprivate static let libraryComparator = Logger(category: "libraryComparator")
 }
 
+private enum TokenSearchError: LocalizedError {
+  case invalidCompareTokenID(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidCompareTokenID(let string):
+      String(localized: "Invalid Token: \(string).")
+    }
+  }
+}
+
 extension Collection where Element == Artist {
   fileprivate func lookups<Identifier: ArchiveIdentifier>(
     _ identifier: Identifier, tokenizer: LibraryCompareTokenizer
@@ -150,25 +161,21 @@ struct Bracket<Identifier: ArchiveIdentifier>: Codable, Sendable {
 
   func compare<Comparable: Identifiable & LibraryComparable & PathRestorable>(
     lhs: Comparable, rhs: Comparable
-  ) -> Bool where Comparable.ID == String, Identifier.ID == Comparable.ID {
-    compare(lhs: lhs, lhsID: lhs.id, rhs: rhs, rhsID: rhs.id)
+  ) throws -> Bool where Comparable.ID == String, Identifier.ID == Comparable.ID {
+    try compare(lhs: lhs, lhsID: lhs.id, rhs: rhs, rhsID: rhs.id)
   }
 
-  func compare<T: Identifiable & LibraryComparable>(lhs: T, lhsID: ID, rhs: T, rhsID: ID) -> Bool {
-    let lhToken =
-      compareTokenMap[lhsID]
-      ?? {
-        Logger.libraryComparator.debug(
-          "\(String(describing: lhs.id), privacy: .public) not in map.")
-        return LibraryCompareTokenizer().removeCommonInitialPunctuation(lhs.librarySortString)
-      }()
-    let rhToken =
-      compareTokenMap[rhsID]
-      ?? {
-        Logger.libraryComparator.debug(
-          "\(String(describing: rhs.id), privacy: .public) not in map.")
-        return LibraryCompareTokenizer().removeCommonInitialPunctuation(rhs.librarySortString)
-      }()
+  func compare<T: Identifiable & LibraryComparable>(lhs: T, lhsID: ID, rhs: T, rhsID: ID) throws
+    -> Bool
+  {
+    guard let lhToken = compareTokenMap[lhsID] else {
+      throw TokenSearchError.invalidCompareTokenID(lhsID.description)
+    }
+
+    guard let rhToken = compareTokenMap[rhsID] else {
+      throw TokenSearchError.invalidCompareTokenID(rhsID.description)
+    }
+
     return lhToken.tokenCompare(other: rhToken)
   }
 }

--- a/Sources/MusicData/Lookup.swift
+++ b/Sources/MusicData/Lookup.swift
@@ -48,12 +48,14 @@ public struct Lookup<Identifier: ArchiveIdentifier>: Codable, Sendable {
 
   func compare<Comparable: Identifiable & LibraryComparable & PathRestorable>(
     lhs: Comparable, rhs: Comparable
-  ) -> Bool where Comparable.ID == String, Identifier.ID == Comparable.ID {
-    bracket.compare(lhs: lhs, rhs: rhs)
+  ) throws -> Bool where Comparable.ID == String, Identifier.ID == Comparable.ID {
+    try bracket.compare(lhs: lhs, rhs: rhs)
   }
 
-  func compare<T: Identifiable & LibraryComparable>(lhs: T, lhsID: ID, rhs: T, rhsID: ID) -> Bool {
-    bracket.compare(lhs: lhs, lhsID: lhsID, rhs: rhs, rhsID: rhsID)
+  func compare<T: Identifiable & LibraryComparable>(lhs: T, lhsID: ID, rhs: T, rhsID: ID) throws
+    -> Bool
+  {
+    try bracket.compare(lhs: lhs, lhsID: lhsID, rhs: rhs, rhsID: rhsID)
   }
 
   var showMap: [ID: Show] {

--- a/Sources/MusicData/Vault.swift
+++ b/Sources/MusicData/Vault.swift
@@ -87,8 +87,8 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
     .suffix(recentCount)
   }
 
-  func concerts(on dayOfLeapYear: Int) -> [Concert] {
-    lookup.concertDayMap[dayOfLeapYear]?.compactMap { lookup.concert(showId: $0) }.sorted(
+  func concerts(on dayOfLeapYear: Int) throws -> [Concert] {
+    try lookup.concertDayMap[dayOfLeapYear]?.compactMap { lookup.concert(showId: $0) }.sorted(
       by: compareConcerts(lhs:rhs:)) ?? []
   }
 
@@ -98,7 +98,7 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
   ///   - lhs: The left-hand concert to compare.
   ///   - rhs: The right-hand concert to compare.
   /// - Returns: `true` if `lhs` should be ordered before `rhs`.
-  func compareConcerts(lhs: Concert, rhs: Concert) -> Bool {
+  func compareConcerts(lhs: Concert, rhs: Concert) throws -> Bool {
     let lhShow = lhs.show
     let rhShow = rhs.show
     if lhShow.date == rhShow.date {
@@ -109,10 +109,10 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
           if lhHeadliner == rhHeadliner {
             return lhs.id < rhs.id
           }
-          return compare(lhs: lhHeadliner, rhs: rhHeadliner)
+          return try compare(lhs: lhHeadliner, rhs: rhHeadliner)
         }
       }
-      return compare(lhs: lhVenue, rhs: rhVenue)
+      return try compare(lhs: lhVenue, rhs: rhVenue)
     }
     return lhShow.date < rhShow.date
   }
@@ -128,9 +128,10 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
   func compare<Comparable: Identifiable & LibraryComparable & PathRestorable>(
     lhs: Comparable, rhs: Comparable
   )
-    -> Bool where Comparable.ID == String
+    throws -> Bool where Comparable.ID == String
   {
-    identifier.libraryCompare(lhs: lhs, rhs: rhs, comparator: lookup.compare(lhs:lhsID:rhs:rhsID:))
+    try identifier.libraryCompare(
+      lhs: lhs, rhs: rhs, comparator: lookup.compare(lhs:lhsID:rhs:rhsID:))
   }
 
   func artistIDs(filteredBy searchString: String) -> any Sequence<ID> {
@@ -142,15 +143,15 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
     }
   }
 
-  func artists(filteredBy searchString: String) -> [Artist] {
+  func artists(filteredBy searchString: String) throws -> [Artist] {
     guard !searchString.isEmpty else { return [] }
 
     let matchingPairs: [(ID, Artist)] = artistIDs().compactMap {
       guard $0.1.filter(by: searchString) else { return nil }
       return $0
     }
-    return matchingPairs.sorted(by: {
-      lookup.compare(lhs: $0.1, lhsID: $0.0, rhs: $1.1, rhsID: $1.0)
+    return try matchingPairs.sorted(by: {
+      try lookup.compare(lhs: $0.1, lhsID: $0.0, rhs: $1.1, rhsID: $1.0)
     }).map { $0.1 }
   }
 
@@ -163,15 +164,15 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
     }
   }
 
-  func venues(filteredBy searchString: String) -> [Venue] {
+  func venues(filteredBy searchString: String) throws -> [Venue] {
     guard !searchString.isEmpty else { return [] }
 
     let matchingPairs: [(ID, Venue)] = venueIDs().compactMap {
       guard $0.1.filter(by: searchString) else { return nil }
       return $0
     }
-    return matchingPairs.sorted(by: {
-      lookup.compare(lhs: $0.1, lhsID: $0.0, rhs: $1.1, rhsID: $1.0)
+    return try matchingPairs.sorted(by: {
+      try lookup.compare(lhs: $0.1, lhsID: $0.0, rhs: $1.1, rhsID: $1.0)
     }).map { $0.1 }
   }
 

--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -99,25 +99,50 @@ public typealias VaultModel = AbstractVaultModel<BasicIdentifier>
 
   @MainActor
   func concerts(on dayOfLeapYear: Int) -> [Concert] {
-    vault.concerts(on: dayOfLeapYear)
+    do {
+      return try vault.concerts(on: dayOfLeapYear)
+    } catch {
+      self.error = error
+      return []
+    }
   }
 
   func artists(filteredBy searchString: String) -> [Artist] {
-    vault.artists(filteredBy: searchString)
+    do {
+      return try vault.artists(filteredBy: searchString)
+    } catch {
+      self.error = error
+      return []
+    }
   }
 
   func venues(filteredBy searchString: String) -> [Venue] {
-    vault.venues(filteredBy: searchString)
+    do {
+      return try vault.venues(filteredBy: searchString)
+    } catch {
+      self.error = error
+      return []
+    }
   }
 
   func compare<Comparable: Identifiable & LibraryComparable & PathRestorable>(
     lhs: Comparable, rhs: Comparable
   ) -> Bool where Comparable.ID == String {
-    vault.compare(lhs: lhs, rhs: rhs)
+    do {
+      return try vault.compare(lhs: lhs, rhs: rhs)
+    } catch {
+      self.error = error
+      return false
+    }
   }
 
   func compareConcerts(lhs: Concert, rhs: Concert) -> Bool {
-    vault.compareConcerts(lhs: lhs, rhs: rhs)
+    do {
+      return try vault.compareConcerts(lhs: lhs, rhs: rhs)
+    } catch {
+      self.error = error
+      return false
+    }
   }
 
   @MainActor

--- a/Tests/SiteTests/ConcertComparatorTests.swift
+++ b/Tests/SiteTests/ConcertComparatorTests.swift
@@ -42,8 +42,8 @@ struct ConcertComparatorTests {
     let concert2 = vaultTest.concert(show: show2.id)!
 
     #expect(concert1 != concert2)
-    #expect(vaultTest.compareConcerts(lhs: concert1, rhs: concert2))
-    #expect(!vaultTest.compareConcerts(lhs: concert2, rhs: concert1))
+    #expect(try vaultTest.compareConcerts(lhs: concert1, rhs: concert2))
+    #expect(try !vaultTest.compareConcerts(lhs: concert2, rhs: concert1))
   }
 
   @Test func sameDates_differentVenues() async throws {
@@ -57,8 +57,8 @@ struct ConcertComparatorTests {
     let concert2 = vaultTest.concert(show: show2.id)!
 
     #expect(concert1 != concert2)
-    #expect(!vaultTest.compareConcerts(lhs: concert1, rhs: concert2))
-    #expect(vaultTest.compareConcerts(lhs: concert2, rhs: concert1))
+    #expect(try !vaultTest.compareConcerts(lhs: concert1, rhs: concert2))
+    #expect(try vaultTest.compareConcerts(lhs: concert2, rhs: concert1))
   }
 
   @Test func sameDates_sameVenues_differentArtists() async throws {
@@ -72,8 +72,8 @@ struct ConcertComparatorTests {
     let concert2 = vaultTest.concert(show: show2.id)!
 
     #expect(concert1 != concert2)
-    #expect(vaultTest.compareConcerts(lhs: concert1, rhs: concert2))
-    #expect(!vaultTest.compareConcerts(lhs: concert2, rhs: concert1))
+    #expect(try vaultTest.compareConcerts(lhs: concert1, rhs: concert2))
+    #expect(try !vaultTest.compareConcerts(lhs: concert2, rhs: concert1))
   }
 
   @Test func sameDates_sameVenues_sameArtists() async throws {
@@ -87,8 +87,8 @@ struct ConcertComparatorTests {
     let concert2 = vaultTest.concert(show: show2.id)!
 
     #expect(concert1 != concert2)
-    #expect(vaultTest.compareConcerts(lhs: concert1, rhs: concert2))
-    #expect(!vaultTest.compareConcerts(lhs: concert2, rhs: concert1))
+    #expect(try vaultTest.compareConcerts(lhs: concert1, rhs: concert2))
+    #expect(try !vaultTest.compareConcerts(lhs: concert2, rhs: concert1))
   }
 
   @Test func edgeCase() async throws {
@@ -102,7 +102,7 @@ struct ConcertComparatorTests {
     let concert2 = vaultTest.concert(show: show2.id)!
 
     #expect(concert1 == concert2)
-    #expect(!vaultTest.compareConcerts(lhs: concert1, rhs: concert2))
-    #expect(!vaultTest.compareConcerts(lhs: concert2, rhs: concert1))
+    #expect(try !vaultTest.compareConcerts(lhs: concert1, rhs: concert2))
+    #expect(try !vaultTest.compareConcerts(lhs: concert2, rhs: concert1))
   }
 }


### PR DESCRIPTION
- This will propagate the Error up and show the error in the UI via the VaultModel.
- All paths to compare will try/throw now.