### PR TITLE
Update ArchivePath associated types

### DIFF
--- a/Sources/MusicData/ArchivePath.swift
+++ b/Sources/MusicData/ArchivePath.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 public enum ArchivePath: Hashable, Sendable {
-  case show(Show.ID)
-  case venue(Venue.ID)
-  case artist(Artist.ID)
+  case show(String)
+  case venue(String)
+  case artist(String)
   case year(Annum)
 }


### PR DESCRIPTION
When Show,Artist,Venue.ID is ArchivePath, we do not want this to be recursive. Therefore the associated types are the Strings in the JSON.