### PR TITLE
Add SiteModel.Reason to pass to load

### DIFF
--- a/Sources/App/SiteAppApp.swift
+++ b/Sources/App/SiteAppApp.swift
@@ -20,7 +20,7 @@ struct SiteAppApp: App {
     }
     #if !os(tvOS)
       .commands {
-        RefreshCommand { await model.load(logString: "refreshCommand") }
+        RefreshCommand { await model.load(.refresh) }
       }
     #endif
     #if os(macOS)

--- a/Sources/Site/Music/SiteModel.swift
+++ b/Sources/Site/Music/SiteModel.swift
@@ -13,6 +13,22 @@ extension Logger {
 }
 
 @Observable public final class SiteModel {
+  public enum Reason {
+    case preview
+    case initial
+    case refresh
+    case errorRetry
+
+    fileprivate var executeAsynchronousTasks: Bool {
+      switch self {
+      case .preview:
+        false
+      default:
+        true
+      }
+    }
+  }
+
   private let urlString: String
 
   public var vaultModel: VaultModel?
@@ -25,26 +41,21 @@ extension Logger {
   }
 
   @MainActor
-  private func load(executeAsynchronousTasks: Bool = true) async {
+  public func load(_ reason: Reason) async {
+    Logger.vaultLoader.log("start: \(String(describing: reason), privacy: .public)")
+    defer {
+      Logger.vaultLoader.log("end: \(String(describing: reason), privacy: .public)")
+    }
     do {
       error = nil
 
       let vault = try await Vault.load(urlString, identifier: BasicIdentifier())
 
       vaultModel?.cancelTasks()
-      vaultModel = VaultModel(vault, executeAsynchronousTasks: executeAsynchronousTasks)
+      vaultModel = VaultModel(vault, executeAsynchronousTasks: reason.executeAsynchronousTasks)
     } catch {
       Logger.vaultLoader.fault("error: \(error.localizedDescription, privacy: .public)")
       self.error = error
     }
-  }
-
-  @MainActor
-  public func load(logString: String, executeAsynchronousTasks: Bool = true) async {
-    Logger.vaultLoader.log("start: \(logString, privacy: .public)")
-    defer {
-      Logger.vaultLoader.log("end: \(logString, privacy: .public)")
-    }
-    await load(executeAsynchronousTasks: executeAsynchronousTasks)
   }
 }

--- a/Sources/Site/Music/UI/SiteView.swift
+++ b/Sources/Site/Music/UI/SiteView.swift
@@ -18,7 +18,7 @@ public struct SiteView: View {
     Group {
       if let vaultModel = model.vaultModel {
         ArchiveStateView {
-          await model.load(logString: "userRefresh")
+          await model.load(.refresh)
         }
         .environment(vaultModel)
       } else if let error = model.error {
@@ -28,7 +28,7 @@ public struct SiteView: View {
             description: Text("Unable to load data."))
           Button {
             Task {
-              await model.load(logString: "errorRetry")
+              await model.load(.errorRetry)
             }
           } label: {
             Label(String(localized: "Retry"), systemImage: "arrow.clockwise")
@@ -41,7 +41,7 @@ public struct SiteView: View {
     }.task {
       guard model.vaultModel == nil, model.error == nil else { return }
 
-      await model.load(logString: "initial")
+      await model.load(.initial)
     }
   }
 }

--- a/Sources/Site/Music/UI/VaultPreviewModifier.swift
+++ b/Sources/Site/Music/UI/VaultPreviewModifier.swift
@@ -14,7 +14,7 @@ private enum VaultPreviewError: Error {
 struct VaultPreviewModifier: PreviewModifier {
   static func makeSharedContext() async throws -> VaultModel {
     let siteModel = SiteModel(urlString: "https://www.bolsinga.com/json/shows.json")
-    await siteModel.load(logString: "preview", executeAsynchronousTasks: false)
+    await siteModel.load(.preview)
     guard siteModel.error == nil else { throw siteModel.error! }
     guard let vaultModel = siteModel.vaultModel else { throw VaultPreviewError.noModel }
     return vaultModel
@@ -31,7 +31,7 @@ struct VaultErrorPreviewModifier: PreviewModifier {
 
   static func makeSharedContext() async throws -> VaultModel {
     let siteModel = SiteModel(urlString: "https://www.bolsinga.com/json/shows.json")
-    await siteModel.load(logString: "errorPreview", executeAsynchronousTasks: false)
+    await siteModel.load(.preview)
     guard siteModel.error == nil else { throw siteModel.error! }
     guard let vaultModel = siteModel.vaultModel else { throw VaultPreviewError.noModel }
     return vaultModel


### PR DESCRIPTION
- More typed, allows for data (such as executeAsynchronousTasks) to tag along by type