### PR TITLE
Cache Bracket as json

### DIFF
--- a/Sources/MusicData/Bracket.swift
+++ b/Sources/MusicData/Bracket.swift
@@ -110,7 +110,7 @@ struct Bracket<Identifier: ArchiveIdentifier>: Codable, Sendable {
 
   let timestamp: Date
 
-  init(music: Music, identifier: Identifier) async throws {
+  init(music: Music, identifier: Identifier, timestamp: Date) async throws {
     async let (artistSortTokens, artistMap, venueSortTokens, venueMap) = try music.itemMaps(
       identifier)
 
@@ -140,7 +140,7 @@ struct Bracket<Identifier: ArchiveIdentifier>: Codable, Sendable {
       (_, new) in new
     }
     self.relationMap = try await relations
-    self.timestamp = music.timestamp
+    self.timestamp = timestamp
   }
 
   /// Creates a new `Bracket` by deriving ranking and lookup maps from the provided `Music` archive.
@@ -156,8 +156,8 @@ struct Bracket<Identifier: ArchiveIdentifier>: Codable, Sendable {
     var signpost = Signpost(category: "bracket", name: "url")
     signpost.start()
 
-    let music = try await Music.load(url: url)
-    try await self.init(music: music, identifier: identifier)
+    let (music, lastModified) = try await Music.load(url: url)
+    try await self.init(music: music, identifier: identifier, timestamp: lastModified)
   }
 
   func compareIDs(lhs: ID, rhs: ID) throws -> Bool {
@@ -212,5 +212,19 @@ struct Bracket<Identifier: ArchiveIdentifier>: Codable, Sendable {
       }
       return lhShowDate < rhShowDate
     }
+  }
+}
+
+private let bracketFileName = "bracket.json"
+
+extension Bracket {
+  static func read(fileManager: FileManager = .default, deleteFile: Bool = false)
+    throws -> Self
+  {
+    try fileManager.readCache(fileName: bracketFileName, deleteFile: deleteFile)
+  }
+
+  func save(fileManager: FileManager = .default) throws {
+    try fileManager.saveCache(cacheData: self, fileName: bracketFileName)
   }
 }

--- a/Sources/MusicData/Lookup.swift
+++ b/Sources/MusicData/Lookup.swift
@@ -6,6 +6,11 @@
 //
 
 import Foundation
+import os
+
+extension Logger {
+  fileprivate static let bracketCache = Logger(category: "bracketCache")
+}
 
 /// A public facade for querying archive data by stable identifiers.
 ///
@@ -40,14 +45,29 @@ public struct Lookup<Identifier: ArchiveIdentifier>: Codable, Sendable {
   /// - Parameters:
   ///   - url: The `URL` where the JSON music data is.
   ///   - identifier: An `ArchiveIdentifier` used to generate stable IDs for all lookups.
+  ///   - previousModified: The `Date` saved as the last modified date of the music data.
   /// - Throws: Any error encountered while reading the archive or computing derived structures.
-  public init(url: URL, identifier: Identifier) async throws {
+  public init(
+    url: URL,
+    identifier: Identifier,
+    previousModified: Date
+  ) async throws {
     var signpost = Signpost(category: "lookup", name: "process")
     signpost.start()
 
-    async let bracket = await Bracket(url: url, identifier: identifier)
+    if try await url.isUpdated(since: previousModified) {
+      Logger.bracketCache.info("loading")
+      let bracket = try await Bracket(url: url, identifier: identifier)
+      try bracket.save()
+      try await self.init(bracket: bracket)
+    } else {
+      var signpost = Signpost(category: "bracket", name: "cache")
+      signpost.start()
 
-    try await self.init(bracket: try await bracket)
+      Logger.bracketCache.info("cached")
+      async let bracket = try Bracket<Identifier>.read()
+      try await self.init(bracket: bracket)
+    }
   }
 
   func compareIDs(lhs: ID, rhs: ID) throws -> Bool {
@@ -224,5 +244,9 @@ public struct Lookup<Identifier: ArchiveIdentifier>: Codable, Sendable {
   /// - Returns: An array of show IDs ordered from oldest to newest within the requested window.
   public func recentConcerts(_ count: Int) -> [ID] {
     bracket.showOrder.suffix(count)
+  }
+
+  public var timestamp: Date {
+    bracket.timestamp
   }
 }

--- a/Sources/MusicData/Music+URL.swift
+++ b/Sources/MusicData/Music+URL.swift
@@ -9,22 +9,27 @@ import Foundation
 import os
 
 extension Logger {
-  fileprivate static let url = Logger(category: "url")
   fileprivate static let music = Logger(category: "music")
 }
 
 extension Music {
-  public static func load(url: URL, artistsWithShowsOnly: Bool = true) async throws -> Music {
-    Logger.music.log("start")
+  public static func load(
+    url: URL,
+    artistsWithShowsOnly: Bool = true
+  ) async throws -> (Music, Date) {
+    Logger.music.log("start: \(String(describing: url))")
     defer {
       Logger.music.log("end")
     }
 
-    Logger.url.log("start: \(url.absoluteString, privacy: .public)")
-    let (data, _) = try await URLSession.shared.data(from: url)
-    Logger.url.log("end")
+    let (data, response) = try await URLSession.shared.data(from: url)
+
+    var lastModified = Date.distantPast
+    if let lastModifiedDate = try response.lastModified() {
+      lastModified = lastModifiedDate
+    }
 
     let music: Music = try data.fromJSON()
-    return artistsWithShowsOnly ? music.showsOnly : music
+    return artistsWithShowsOnly ? (music.showsOnly, lastModified) : (music, lastModified)
   }
 }

--- a/Sources/MusicData/Vault+URL.swift
+++ b/Sources/MusicData/Vault+URL.swift
@@ -13,9 +13,11 @@ extension Logger {
 }
 
 extension Vault where Identifier: ArchiveIdentifier {
-  public static func load(_ urlString: String, identifier: Identifier) async throws
-    -> Vault<Identifier>
-  {
+  public static func load(
+    _ urlString: String,
+    identifier: Identifier,
+    previousModified: Date
+  ) async throws -> Vault<Identifier> {
     Logger.vault.log("start")
     defer {
       Logger.vault.log("end")
@@ -23,6 +25,6 @@ extension Vault where Identifier: ArchiveIdentifier {
 
     guard let url = URL(string: urlString) else { throw VaultError.illegalURL(urlString) }
 
-    return try await Vault(url: url, identifier: identifier)
+    return try await Vault(url: url, identifier: identifier, previousModified: previousModified)
   }
 }

--- a/Sources/MusicData/Vault.swift
+++ b/Sources/MusicData/Vault.swift
@@ -27,13 +27,16 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
     }
   }
 
-  public init(url: URL, identifier: Identifier) async throws {
+  public init(url: URL, identifier: Identifier, previousModified: Date) async throws {
     var signpost = Signpost(category: "vault", name: "process")
     signpost.start()
 
     guard let rootURL = url.rootURL else { throw VaultError.noRootURL(url.absoluteString) }
 
-    async let asyncLookup = await Lookup(url: url, identifier: identifier)
+    async let asyncLookup = await Lookup(
+      url: url,
+      identifier: identifier,
+      previousModified: previousModified)
     self.init(lookup: try await asyncLookup, rootURL: rootURL)
   }
 
@@ -212,5 +215,9 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
         Array(repeating: venue.location, count: self.shows(venueID: id).count)
       }.stateCounts
     )
+  }
+
+  var timestamp: Date {
+    lookup.timestamp
   }
 }

--- a/Sources/Site/Music/SiteModel.swift
+++ b/Sources/Site/Music/SiteModel.swift
@@ -15,7 +15,7 @@ extension Logger {
 @Observable public final class SiteModel {
   public enum Reason {
     case preview
-    case initial
+    case initial(Date)
     case refresh
     case errorRetry
 
@@ -34,10 +34,23 @@ extension Logger {
   public var vaultModel: VaultModel?
   internal var error: Error?
 
+  var lastModified: Date = .distantPast
+
   public init(urlString: String, vaultModel: VaultModel? = nil, error: Error? = nil) {
     self.urlString = urlString
     self.vaultModel = vaultModel
     self.error = error
+  }
+
+  private func modifiedDate(_ reason: Reason) -> Date {
+    switch reason {
+    case .preview, .errorRetry:
+      .distantPast
+    case .initial(let date):
+      date
+    case .refresh:
+      lastModified
+    }
   }
 
   @MainActor
@@ -49,7 +62,11 @@ extension Logger {
     do {
       error = nil
 
-      let vault = try await Vault.load(urlString, identifier: BasicIdentifier())
+      let vault = try await Vault.load(
+        urlString,
+        identifier: BasicIdentifier(),
+        previousModified: modifiedDate(reason))
+      self.lastModified = vault.timestamp
 
       vaultModel?.cancelTasks()
       vaultModel = VaultModel(vault, executeAsynchronousTasks: reason.executeAsynchronousTasks)

--- a/Sources/Site/Music/UI/SiteView.swift
+++ b/Sources/Site/Music/UI/SiteView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 public struct SiteView: View {
+  @AppStorage("music.last.modified") private var musicLastModified: Date = .distantPast
   private let model: SiteModel
 
   public init(_ model: SiteModel) {
@@ -41,7 +42,10 @@ public struct SiteView: View {
     }.task {
       guard model.vaultModel == nil, model.error == nil else { return }
 
-      await model.load(.initial)
+      await model.load(.initial(musicLastModified))
+    }
+    .onChange(of: model.lastModified) { _, newValue in
+      musicLastModified = newValue
     }
   }
 }

--- a/Sources/Utilities/URL+LastModified.swift
+++ b/Sources/Utilities/URL+LastModified.swift
@@ -1,0 +1,24 @@
+//
+//  URL+LastModified.swift
+//  SiteApp
+//
+//  Created by Greg Bolsinga on 5/23/26.
+//
+
+import Foundation
+
+extension URL {
+  private func lastModified() async throws -> Date? {
+    var request = URLRequest(url: self)
+    request.httpMethod = "HEAD"
+
+    let (_, response) = try await URLSession.shared.data(for: request)
+
+    return try response.lastModified()
+  }
+
+  func isUpdated(since lastKnown: Date) async throws -> Bool {
+    guard let lastModified = try await lastModified() else { return true }
+    return lastModified > lastKnown
+  }
+}

--- a/Sources/Utilities/URLResponse+LastModified.swift
+++ b/Sources/Utilities/URLResponse+LastModified.swift
@@ -1,0 +1,20 @@
+//
+//  URLResponse+LastModified.swift
+//  SiteApp
+//
+//  Created by Greg Bolsinga on 5/23/26.
+//
+
+import Foundation
+
+extension URLResponse {
+  func lastModified() throws -> Date? {
+    var lastModified: Date? = nil
+    if let httpResponse = self as? HTTPURLResponse {
+      if let lastModifiedString = httpResponse.value(forHTTPHeaderField: "Last-Modified") {
+        lastModified = try Date(lastModifiedString, strategy: .http)
+      }
+    }
+    return lastModified
+  }
+}

--- a/Sources/site_tool/RootURLArguments+Lookup.swift
+++ b/Sources/site_tool/RootURLArguments+Lookup.swift
@@ -11,6 +11,6 @@ extension RootURLArguments {
   func lookup<Identifier: ArchiveIdentifier>(identifier: Identifier) async throws
     -> Lookup<Identifier>
   {
-    try await Lookup(url: showsURL, identifier: identifier)
+    try await Lookup(url: showsURL, identifier: identifier, previousModified: .distantPast)
   }
 }

--- a/Sources/site_tool/RootURLArguments+Vault.swift
+++ b/Sources/site_tool/RootURLArguments+Vault.swift
@@ -12,6 +12,9 @@ extension RootURLArguments {
     async throws
     -> Vault<Identifier>
   {
-    try await Vault.load(url.appending(path: fileName).absoluteString, identifier: identifier)
+    try await Vault.load(
+      url.appending(path: fileName).absoluteString,
+      identifier: identifier,
+      previousModified: .distantPast)
   }
 }

--- a/Tests/SiteTests/ShowDigestComparisonTests.swift
+++ b/Tests/SiteTests/ShowDigestComparisonTests.swift
@@ -34,7 +34,7 @@ struct ShowDigestComparisonTests {
             timestamp: Date(),
             venues: venues),
           identifier: ArchivePathIdentifier(),
-          previousModified: .now)),
+          timestamp: .now)),
       rootURL: URL(string: "https://www.example.com/")!)
   }
 

--- a/Tests/SiteTests/ShowDigestComparisonTests.swift
+++ b/Tests/SiteTests/ShowDigestComparisonTests.swift
@@ -33,7 +33,8 @@ struct ShowDigestComparisonTests {
             songs: [],
             timestamp: Date(),
             venues: venues),
-          identifier: ArchivePathIdentifier())),
+          identifier: ArchivePathIdentifier(),
+          previousModified: .now)),
       rootURL: URL(string: "https://www.example.com/")!)
   }
 


### PR DESCRIPTION
- Store the lastModified date in AppStorage. Use it to see if the URL data is newer than the cached Bracket.json. Saved 150ms on launch on macos, so should be a good win on ios / cellular.
- if the lastModified date is set, and file error occurs (tested via deleting the cache file), the user is presented with a retry error screen, which will then load it from the network.
- Reminder: AppStorage macos: defaults delete gdb.SiteApp
- Reminder: Cache file macos: ~/Library/Containers/gdb.SiteApp/Data/Library/Caches/bracket.json
- Fixes: #1252