### PR TITLE
improve location disabled/restricted UI

### DIFF
--- a/Sources/App/Localizable.xcstrings
+++ b/Sources/App/Localizable.xcstrings
@@ -286,13 +286,7 @@
     "Location" : {
 
     },
-    "Location Disabled" : {
-
-    },
-    "Location Services are disabled. Disable the Location Filter." : {
-
-    },
-    "Location Services are not available. Disable the Location Filter." : {
+    "Location Services are disabled. Enable access in Settings." : {
 
     },
     "Location Unavailable" : {

--- a/Sources/Site/Music/UI/ArchiveCategoryToolbarContent.swift
+++ b/Sources/Site/Music/UI/ArchiveCategoryToolbarContent.swift
@@ -40,8 +40,10 @@ struct ArchiveCategoryToolbarContent: ToolbarContent {
         }
       }
     }
-    if category.isLocationFilterable {
-      LocationFilterToolbarContent { showNearbyDistanceSettings = true }
+    if category.isLocationFilterable, model.locationAuthorization.uiEnabled {
+      LocationFilterToolbarContent(locationAuthorization: model.locationAuthorization) {
+        showNearbyDistanceSettings = true
+      }
     }
     ArchiveSharableToolbarContent(
       item: ArchiveCategorySharable(

--- a/Sources/Site/Music/UI/LocationFilterToolbarContent.swift
+++ b/Sources/Site/Music/UI/LocationFilterToolbarContent.swift
@@ -24,15 +24,47 @@ import SwiftUI
   private let showLocationFilterSettingsMenu = false
 #endif
 
+extension LocationAuthorization {
+  fileprivate var toggleSystemImage: String {
+    switch self {
+    case .allowed:
+      "location.circle"
+    case .restricted, .denied:
+      "location.slash.circle"
+    }
+  }
+
+  fileprivate func menuSystemImage(_ isNearby: Bool) -> String {
+    switch self {
+    case .allowed:
+      isNearby ? "location.circle.fill" : "location.circle"
+    case .restricted, .denied:
+      isNearby ? "location.slash.circle.fill" : "location.slash.circle"
+    }
+  }
+
+  fileprivate var uiDisabled: Bool {
+    switch self {
+    case .allowed, .denied:
+      false
+    case .restricted:
+      true
+    }
+  }
+}
+
 struct LocationFilterToolbarContent: ToolbarContent {
+  let locationAuthorization: LocationAuthorization
   let placement: ToolbarItemPlacement
   @Environment(NearbyModel.self) var nearbyModel
   let editNearbyDistanceAction: @MainActor () -> Void
 
   internal init(
+    locationAuthorization: LocationAuthorization,
     placement: ToolbarItemPlacement = .primaryAction,
     editNearbyDistanceAction: @escaping @MainActor () -> Void
   ) {
+    self.locationAuthorization = locationAuthorization
     self.placement = placement
     self.editNearbyDistanceAction = editNearbyDistanceAction
   }
@@ -40,8 +72,11 @@ struct LocationFilterToolbarContent: ToolbarContent {
   @ViewBuilder private var nearbyToggle: some View {
     @Bindable var bindableNearbyModel = nearbyModel
     Toggle(
-      String(localized: "Filter Nearby"), systemImage: "location.circle",
-      isOn: $bindableNearbyModel.locationFilter.toggle)
+      String(localized: "Filter Nearby"),
+      systemImage: locationAuthorization.toggleSystemImage,
+      isOn: $bindableNearbyModel.locationFilter.toggle
+    )
+    .disabled(locationAuthorization.uiDisabled)
   }
 
   @ViewBuilder private var nearbySettingsMenu: some View {
@@ -56,11 +91,11 @@ struct LocationFilterToolbarContent: ToolbarContent {
     } label: {
       Label(
         String(localized: "Filter Nearby"),
-        systemImage: nearbyModel.locationFilter.isNearby
-          ? "location.circle.fill" : "location.circle")
+        systemImage: locationAuthorization.menuSystemImage(nearbyModel.locationFilter.isNearby))
     } primaryAction: {
       nearbyModel.locationFilter.toggle.toggle()
     }
+    .disabled(locationAuthorization.uiDisabled)
   }
 
   var body: some ToolbarContent {

--- a/Sources/Site/Music/UI/NearbyLocationView.swift
+++ b/Sources/Site/Music/UI/NearbyLocationView.swift
@@ -7,12 +7,33 @@
 
 import SwiftUI
 
+private enum Authorization {
+  case allowed
+  case denied
+}
+
+extension LocationAuthorization {
+  fileprivate var authorization: Authorization {
+    switch self {
+    case .allowed:
+      .allowed
+    case .restricted, .denied:
+      .denied
+    }
+  }
+}
+
 struct NearbyLocationView: View {
-  let locationAuthorization: LocationAuthorization
+  internal init(locationAuthorization: LocationAuthorization, filteredDataIsEmpty: Bool) {
+    self.authorization = locationAuthorization.authorization
+    self.filteredDataIsEmpty = filteredDataIsEmpty
+  }
+
+  private let authorization: Authorization
   let filteredDataIsEmpty: Bool
 
   var body: some View {
-    switch locationAuthorization {
+    switch authorization {
     case .allowed:
       if filteredDataIsEmpty {
         ContentUnavailableView(
@@ -23,19 +44,12 @@ struct NearbyLocationView: View {
           )
         )
       }
-    case .restricted:
-      ContentUnavailableView(
-        String(localized: "Location Disabled"),
-        systemImage: "location.slash.circle",
-        description: Text(
-          "Location Services are disabled. Disable the Location Filter.")
-      )
     case .denied:
       ContentUnavailableView(
         String(localized: "Location Unavailable"),
         systemImage: "location.slash.circle",
         description: Text(
-          "Location Services are not available. Disable the Location Filter.")
+          "Location Services are disabled. Enable access in Settings.")
       )
     }
   }

--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -19,6 +19,15 @@ enum LocationAuthorization {
   case allowed
   case restricted  // Locations are not possible.
   case denied  // Locations denied by user.
+
+  var uiEnabled: Bool {
+    switch self {
+    case .allowed, .denied:
+      true
+    case .restricted:
+      false
+    }
+  }
 }
 
 public typealias VaultModel = AbstractVaultModel<BasicIdentifier>
@@ -34,7 +43,7 @@ public typealias VaultModel = AbstractVaultModel<BasicIdentifier>
   internal var todayDayOfLeapYear: Int = Date.now.dayOfLeapYear
   private var venueLocatables: [ID: Locatable] = [:]
   private var currentLocation: CLLocation?
-  internal var locationAuthorization = LocationAuthorization.allowed
+  internal var locationAuthorization = LocationAuthorization.restricted
 
   @ObservationIgnored
   private var dayChangeTask: Task<Void, Never>?


### PR DESCRIPTION
- If denied, inform the user how to enable. Also "slash" the UI button for clarity.
- If restricted (basically app does not know why it can't get location), don't show and disable the UI completely, with a "slash" variant.