### PR TITLE
VaultModel's geocoding Map is now ArchivePath -> MKMapItem

### DIFF
--- a/Sources/MusicData/Lookup.swift
+++ b/Sources/MusicData/Lookup.swift
@@ -30,6 +30,8 @@ public struct Lookup<Identifier: ArchiveIdentifier>: Codable, Sendable {
 
   private let showIDOrderIndex: [ID: Int]
 
+  let venueArchivePathMap: [ArchivePath: ID]
+
   private enum LoadAttempt {
     // URL, identifier, previousModified, cacheLoadFailed
     case networkLoad(URL, Identifier, Date, Bool)
@@ -130,6 +132,9 @@ public struct Lookup<Identifier: ArchiveIdentifier>: Codable, Sendable {
     async let ordered = Dictionary(
       uniqueKeysWithValues: try bracket.sortedShowIDs().enumerated().map { ($1, $0) })
     self.showIDOrderIndex = try await ordered
+    self.venueArchivePathMap = bracket.venueMap.reduce(into: [:]) {
+      $0[$1.value.archivePath] = $1.key
+    }
   }
 
   /// Creates a `Lookup` by indexing the provided `Music` archive and preparing derived maps.

--- a/Sources/MusicData/Vault.swift
+++ b/Sources/MusicData/Vault.swift
@@ -220,4 +220,8 @@ public struct Vault<Identifier: ArchiveIdentifier>: Sendable {
   var timestamp: Date {
     lookup.timestamp
   }
+
+  var venueArchivePathMap: [ArchivePath: ID] {
+    lookup.venueArchivePathMap
+  }
 }

--- a/Sources/Site/Music/BatchGeocode.swift
+++ b/Sources/Site/Music/BatchGeocode.swift
@@ -9,7 +9,7 @@ import Foundation
 import MapKit
 
 struct BatchGeocode<Identifier: ArchiveIdentifier>: AsyncSequence {
-  public typealias ID = Identifier.ID
+  public typealias ID = ArchivePath
 
   typealias Element = (ID, MKMapItem?)
 
@@ -22,7 +22,7 @@ struct BatchGeocode<Identifier: ArchiveIdentifier>: AsyncSequence {
   ///   - vault: This is used to find what items will be geocoded, as well as defining ID
   init(atlas: Atlas<Venue>, vault: Vault<Identifier>) {
     self.atlas = atlas
-    self.geocodables = vault.venueIDs()
+    self.geocodables = vault.venueIDs().map { ($0.1.archivePath, $0.1) }
   }
 
   struct AsyncIterator: AsyncIteratorProtocol {

--- a/Sources/Site/Music/UI/VenueDetail.swift
+++ b/Sources/Site/Music/UI/VenueDetail.swift
@@ -79,10 +79,10 @@ struct VenueDetail: View {
     #endif
     .toolbar { ArchiveSharableToolbarContent(item: digest, url: url) }
     .onAppear {
-      self.mapItem = model.venueMapItemMap[digest.id]
+      self.mapItem = model.venueMapItemMap[digest.archivePath]
     }
     .onChange(of: model.venueMapItemMap) { _, newValue in
-      self.mapItem = newValue[digest.id]
+      self.mapItem = newValue[digest.archivePath]
     }
   }
 }

--- a/Sources/Site/Music/VaultModel.swift
+++ b/Sources/Site/Music/VaultModel.swift
@@ -41,7 +41,7 @@ public typealias VaultModel = AbstractVaultModel<BasicIdentifier>
   internal var error: Error?
 
   internal var todayDayOfLeapYear: Int = Date.now.dayOfLeapYear
-  internal var venueMapItemMap: [ID: MKMapItem] = [:]
+  internal var venueMapItemMap: [ArchivePath: MKMapItem] = [:]
   private var currentLocation: CLLocation?
   internal var locationAuthorization = LocationAuthorization.restricted
 
@@ -317,7 +317,7 @@ public typealias VaultModel = AbstractVaultModel<BasicIdentifier>
   {
     venueMapItemMap.compactMap { (id, mapItem) in
       guard mapItem.location.distance(from: location) <= distanceThreshold else { return nil }
-      return id
+      return vault.venueArchivePathMap[id]
     }
   }
 


### PR DESCRIPTION
- This will allow more flexibility going forward prior to a full generic stack.
- Lookup now runs through the venues to make a ArchivePath -> ID map.